### PR TITLE
PostgreSQLのバージョン指定を14から17にする

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ docker compose up
 ## 技術スタック
 
 - Heroku-24
-- PostgreSQL 14
+- PostgreSQL 17
 - Node.js 24
 - Ruby 3
 - Rails 8

--- a/compose.yml
+++ b/compose.yml
@@ -25,7 +25,7 @@ services:
     user: root
     working_dir: /app
   db:
-    image: postgres:14
+    image: postgres:17
     volumes:
       - postgres:/var/lib/postgresql/data
     environment:


### PR DESCRIPTION
## Summary
- bump postgres image in compose.yml to 17
- update README tech stack to mention PostgreSQL 17

## Testing
- docker compose config --services

Resolves #903