### PR TITLE
メールアドレス未確認ユーザー削除スクリプトをrakeタスクにする

### DIFF
--- a/lib/tasks/destroy_not_confirmed_users.rake
+++ b/lib/tasks/destroy_not_confirmed_users.rake
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+namespace :users do
+  desc '作成から1日以上経過したメールアドレス未確認ユーザーを削除する'
+  task destroy_not_confirmed: :environment do
+    users = User.where(confirmed_at: nil).where(created_at: ...1.day.ago)
+
+    if users.none?
+      Rails.logger.info '削除対象のメールアドレス未確認ユーザーはいませんでした'
+      next
+    end
+
+    Rails.logger.info "メールアドレス未確認ユーザーを#{users.count}件削除します"
+
+    users.find_each do |user|
+      Rails.logger.info(
+        [
+          "user_id=#{user.id}",
+          "email=#{user.email}",
+          "name=#{user.name}"
+        ].join(' ')
+      )
+      user.destroy!
+    end
+  end
+end

--- a/lib/tasks/destroy_not_confirmed_users.rb
+++ b/lib/tasks/destroy_not_confirmed_users.rb
@@ -1,8 +1,0 @@
-# frozen_string_literal: true
-
-User.where(confirmed_at: nil).where(created_at: ...1.day.ago).find_each do |user|
-  Rails.logger.info user.id
-  Rails.logger.info user.email
-  Rails.logger.info user.name
-  user.destroy!
-end


### PR DESCRIPTION
## 概要

メールアドレス未確認ユーザー削除スクリプトを、Rails環境付きで実行できるRakeタスクに変更しました。

## 変更内容

- `lib/tasks/destroy_not_confirmed_users.rb` の処理を `lib/tasks/destroy_not_confirmed_users.rake` に移行
- `users:destroy_not_confirmed` タスクとして実行できるように変更
- 削除対象がいない場合のログと、削除対象ユーザーの情報をまとめて出力するログを追加
- 役割を終えた単独スクリプトを削除

## 目的

既存の削除処理を、Railsアプリケーションのタスクとして安全かつ明示的に実行できるようにするためです。

## 影響

メールアドレス未確認かつ作成から1日以上経過したユーザーを、`bin/rails users:destroy_not_confirmed` で実行できるようになります。

## 確認内容

- `docker compose run --rm app bin/rubocop lib/tasks/destroy_not_confirmed_users.rake`

Resolves #1008