### PR TITLE
「人気の歌」の選定ロジックを改善する

### DIFF
--- a/app/models/popular_post.rb
+++ b/app/models/popular_post.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+class PopularPost < ApplicationRecord
+  belongs_to :post
+
+  validates :position, presence: true, numericality: { only_integer: true, greater_than: 0 }
+
+  class << self
+    def rebuild!(now: Time.current, limit: 30)
+      popular_posts = aggregated_posts(now:, limit:)
+
+      transaction do
+        delete_all
+
+        popular_posts.each.with_index(1) do |popular_post, position|
+          create!(
+            post_id: popular_post.post_id,
+            position:
+          )
+        end
+      end
+    end
+
+    private
+
+    def aggregated_posts(now:, limit:)
+      recent_since = now - 1.day
+      reciprocal_since = now - 7.days
+
+      Post.joins(<<~SQL.squish)
+        INNER JOIN follows recent_favorites
+          ON recent_favorites.followable_type = 'Post'
+          AND recent_favorites.followable_id = posts.id
+          AND recent_favorites.follower_type = 'User'
+      SQL
+          .where(recent_favorites: { created_at: recent_since..now })
+          .where(<<~SQL.squish, reciprocal_since:)
+            NOT EXISTS (
+              SELECT 1
+              FROM follows author_favorites
+              INNER JOIN posts liked_posts
+                ON liked_posts.id = author_favorites.followable_id
+              WHERE author_favorites.followable_type = 'Post'
+                AND author_favorites.follower_type = 'User'
+                AND author_favorites.follower_id = posts.user_id
+                AND author_favorites.created_at >= :reciprocal_since
+                AND liked_posts.user_id = recent_favorites.follower_id
+            )
+          SQL
+          .group('posts.id')
+          .select('posts.id AS post_id')
+          .order(Arel.sql('COUNT(recent_favorites.id) DESC'))
+          .order(:created_at)
+          .limit(limit)
+    end
+  end
+end

--- a/db/migrate/20260425000000_create_popular_posts.rb
+++ b/db/migrate/20260425000000_create_popular_posts.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class CreatePopularPosts < ActiveRecord::Migration[8.0]
+  def change
+    create_table :popular_posts do |t|
+      t.references :post, null: false, foreign_key: { on_delete: :cascade }, index: { unique: true }
+      t.integer :position, null: false
+
+      t.timestamps
+    end
+
+    add_index :popular_posts, :position, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_10_10_041834) do
+ActiveRecord::Schema[8.0].define(version: 2026_04_25_000000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -29,6 +29,15 @@ ActiveRecord::Schema[8.0].define(version: 2025_10_10_041834) do
     t.index ["follower_id", "follower_type"], name: "fk_follows"
     t.index ["follower_type", "follower_id"], name: "index_follows_on_follower"
     t.index ["user_id"], name: "index_follows_on_user_id"
+  end
+
+  create_table "popular_posts", force: :cascade do |t|
+    t.bigint "post_id", null: false
+    t.integer "position", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["position"], name: "index_popular_posts_on_position", unique: true
+    t.index ["post_id"], name: "index_popular_posts_on_post_id", unique: true
   end
 
   create_table "posts", force: :cascade do |t|
@@ -71,5 +80,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_10_10_041834) do
   end
 
   add_foreign_key "follows", "users", on_delete: :cascade
+  add_foreign_key "popular_posts", "posts", on_delete: :cascade
   add_foreign_key "posts", "users", on_delete: :cascade
 end

--- a/lib/tasks/popular_posts.rake
+++ b/lib/tasks/popular_posts.rake
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+namespace :popular_posts do
+  desc '人気の歌の掲載順データを再集計する'
+  task rebuild: :environment do
+    PopularPost.rebuild!
+    Rails.logger.info "人気の歌を#{PopularPost.count}件集計しました"
+  end
+end

--- a/test/models/popular_post_test.rb
+++ b/test/models/popular_post_test.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class PopularPostTest < ActiveSupport::TestCase
+  include ActiveSupport::Testing::TimeHelpers
+
+  test 'rebuild creates popular posts ordered by eligible favorites count' do
+    travel_to Time.zone.local(2026, 4, 25, 12, 0, 0) do
+      first_post = create_post(created_at: 3.days.ago)
+      second_post = create_post(created_at: 2.days.ago)
+
+      2.times { |index| create_favorite(post: first_post, liker: create_user("first_liker_#{index}")) }
+      3.times { |index| create_favorite(post: second_post, liker: create_user("second_liker_#{index}")) }
+
+      PopularPost.rebuild!
+
+      assert_equal [second_post.id, first_post.id], PopularPost.order(:position).pluck(:post_id)
+      assert_equal [1, 2], PopularPost.order(:position).pluck(:position)
+    end
+  end
+
+  test 'rebuild ignores favorites from users liked by the post author in the last seven days' do
+    travel_to Time.zone.local(2026, 4, 25, 12, 0, 0) do
+      author = create_user('author')
+      reciprocal_liker = create_user('reciprocal_liker')
+      eligible_liker = create_user('eligible_liker')
+      reciprocal_liker_post = create_post(user: reciprocal_liker)
+      popular_candidate = create_post(user: author)
+
+      create_favorite(post: reciprocal_liker_post, liker: author, created_at: 6.days.ago)
+      create_favorite(post: popular_candidate, liker: reciprocal_liker)
+      create_favorite(post: popular_candidate, liker: eligible_liker)
+
+      PopularPost.rebuild!
+
+      assert_equal [popular_candidate.id], PopularPost.order(:position).pluck(:post_id)
+      assert_equal [1], PopularPost.order(:position).pluck(:position)
+    end
+  end
+
+  test 'rebuild replaces existing popular posts and limits records to thirty' do
+    travel_to Time.zone.local(2026, 4, 25, 12, 0, 0) do
+      old_popular_post = create_post(tanka: '古い人気データ')
+      PopularPost.create!(post: old_popular_post, position: 1)
+
+      31.times do |index|
+        post = create_post(tanka: "人気候補#{index}", created_at: index.days.ago)
+        create_favorite(post:, liker: create_user("liker_#{index}"))
+      end
+
+      PopularPost.rebuild!
+
+      assert_equal 30, PopularPost.count
+      assert_not_includes PopularPost.pluck(:post_id), old_popular_post.id
+    end
+  end
+
+  private
+
+  def create_user(name)
+    User.create!(
+      name:,
+      email: "#{name}@example.com",
+      password: 'password',
+      confirmed_at: Time.current
+    )
+  end
+
+  def create_post(
+    user: create_user("user_#{SecureRandom.hex(4)}"),
+    tanka: SecureRandom.hex(20),
+    created_at: Time.current
+  )
+    Post.create!(
+      user:,
+      tanka:,
+      published_at: created_at,
+      created_at:,
+      updated_at: created_at
+    )
+  end
+
+  def create_favorite(post:, liker:, created_at: Time.current)
+    Follow.create!(
+      followable: post,
+      follower: liker,
+      user_id: liker.id,
+      created_at:,
+      updated_at: created_at
+    )
+  end
+end


### PR DESCRIPTION
## 概要

Issue 1037 の対応として、人気の歌の掲載順データを保持する `popular_posts` テーブルと、集計用の `popular_posts:rebuild` rakeタスクを追加しました。

## 変更内容

- `popular_posts` テーブルを追加し、投稿ID・掲載順を保持できるようにしました
- 既存の人気の歌データを削除してから、直近1日のいいね数が多い順に最大30件を登録する集計処理を追加しました
- 投稿者が直近7日間でいいねしたユーザーからのいいねを集計対象外にしました
- 集計順、いいね返し除外、既存データ入れ替えと30件制限のテストを追加しました

## 確認

- `docker compose run --rm app bin/rails db:migrate`
- `docker compose run --rm app bin/rails test test/models/popular_post_test.rb`
- `docker compose run --rm app bin/rubocop`
