### PR TITLE
「人気の歌」の選定ロジックを改善する

### DIFF
--- a/app/models/popular_post.rb
+++ b/app/models/popular_post.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class PopularPost < ApplicationRecord
+  belongs_to :post
+
+  validates :position, presence: true, uniqueness: true
+  validates :post_id, uniqueness: true
+  validates :favorites_count, presence: true
+end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -6,6 +6,7 @@ class Post < ApplicationRecord
   acts_as_followable
 
   belongs_to :user
+  has_one :popular_post, dependent: :destroy
 
   validates :tanka, presence: true, uniqueness: true, length: { minimum: 5, maximum: 1000 }
   validates :published_at, presence: true

--- a/db/migrate/20260425000000_create_popular_posts.rb
+++ b/db/migrate/20260425000000_create_popular_posts.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class CreatePopularPosts < ActiveRecord::Migration[8.0]
+  def change
+    create_table :popular_posts do |t|
+      t.references :post, null: false, foreign_key: true
+      t.integer :position, null: false
+      t.integer :favorites_count, null: false
+
+      t.timestamps
+    end
+
+    add_index :popular_posts, :position, unique: true
+    add_index :popular_posts, :post_id, unique: true
+  end
+end

--- a/db/migrate/20260425001000_add_popularity_indexes_to_follows.rb
+++ b/db/migrate/20260425001000_add_popularity_indexes_to_follows.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class AddPopularityIndexesToFollows < ActiveRecord::Migration[8.0]
+  def change
+    add_index :follows,
+              %i[followable_type follower_type created_at followable_id follower_id],
+              name: 'index_follows_on_favorite_popularity'
+    add_index :follows,
+              %i[follower_id followable_type follower_type created_at followable_id],
+              name: 'index_follows_on_recent_favorites_by_user'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,66 +10,79 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_10_10_041834) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_25_001000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
   create_table "follows", force: :cascade do |t|
-    t.string "followable_type", null: false
-    t.bigint "followable_id", null: false
-    t.string "follower_type", null: false
-    t.bigint "follower_id", null: false
-    t.bigint "user_id", null: false
-    t.boolean "read", default: false, null: false
     t.boolean "blocked", default: false, null: false
     t.datetime "created_at", precision: nil, null: false
+    t.bigint "followable_id", null: false
+    t.string "followable_type", null: false
+    t.bigint "follower_id", null: false
+    t.string "follower_type", null: false
+    t.boolean "read", default: false, null: false
     t.datetime "updated_at", precision: nil, null: false
+    t.bigint "user_id", null: false
     t.index ["followable_id", "followable_type"], name: "fk_followables"
     t.index ["followable_type", "followable_id"], name: "index_follows_on_followable"
+    t.index ["followable_type", "follower_type", "created_at", "followable_id", "follower_id"], name: "index_follows_on_favorite_popularity"
+    t.index ["follower_id", "followable_type", "follower_type", "created_at", "followable_id"], name: "index_follows_on_recent_favorites_by_user"
     t.index ["follower_id", "follower_type"], name: "fk_follows"
     t.index ["follower_type", "follower_id"], name: "index_follows_on_follower"
     t.index ["user_id"], name: "index_follows_on_user_id"
   end
 
+  create_table "popular_posts", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.integer "favorites_count", null: false
+    t.integer "position", null: false
+    t.bigint "post_id", null: false
+    t.datetime "updated_at", null: false
+    t.index ["position"], name: "index_popular_posts_on_position", unique: true
+    t.index ["post_id"], name: "index_popular_posts_on_post_id", unique: true
+  end
+
   create_table "posts", force: :cascade do |t|
-    t.string "tanka", null: false
-    t.bigint "user_id", null: false
     t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
     t.datetime "published_at", precision: nil, null: false
+    t.string "tanka", null: false
+    t.datetime "updated_at", precision: nil, null: false
+    t.bigint "user_id", null: false
     t.index ["tanka"], name: "index_posts_on_tanka", unique: true
     t.index ["user_id"], name: "index_posts_on_user_id"
   end
 
   create_table "users", force: :cascade do |t|
-    t.string "email", default: "", null: false
-    t.string "encrypted_password", default: "", null: false
-    t.string "reset_password_token"
-    t.datetime "reset_password_sent_at", precision: nil
-    t.datetime "remember_created_at", precision: nil
-    t.integer "sign_in_count", default: 0, null: false
-    t.datetime "current_sign_in_at", precision: nil
-    t.datetime "last_sign_in_at", precision: nil
-    t.string "current_sign_in_ip"
-    t.string "last_sign_in_ip"
-    t.string "confirmation_token"
-    t.datetime "confirmed_at", precision: nil
-    t.datetime "confirmation_sent_at", precision: nil
-    t.string "unconfirmed_email"
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
-    t.string "name", default: "", null: false
-    t.string "profile", default: ""
-    t.string "twitter_id", default: ""
-    t.string "avatar_file_name"
     t.string "avatar_content_type"
+    t.string "avatar_file_name"
     t.bigint "avatar_file_size"
     t.datetime "avatar_updated_at", precision: nil
+    t.datetime "confirmation_sent_at", precision: nil
+    t.string "confirmation_token"
+    t.datetime "confirmed_at", precision: nil
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "current_sign_in_at", precision: nil
+    t.string "current_sign_in_ip"
+    t.string "email", default: "", null: false
+    t.string "encrypted_password", default: "", null: false
+    t.datetime "last_sign_in_at", precision: nil
+    t.string "last_sign_in_ip"
+    t.string "name", default: "", null: false
+    t.string "profile", default: ""
+    t.datetime "remember_created_at", precision: nil
+    t.datetime "reset_password_sent_at", precision: nil
+    t.string "reset_password_token"
+    t.integer "sign_in_count", default: 0, null: false
+    t.string "twitter_id", default: ""
+    t.string "unconfirmed_email"
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["name"], name: "index_users_on_name"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
   add_foreign_key "follows", "users", on_delete: :cascade
+  add_foreign_key "popular_posts", "posts", on_delete: :cascade
   add_foreign_key "posts", "users", on_delete: :cascade
 end

--- a/lib/tasks/popular_posts.rake
+++ b/lib/tasks/popular_posts.rake
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+namespace :popular_posts do
+  desc '人気の歌を集計し直す'
+  task refresh: :environment do
+    popularity_sql = <<~SQL.squish
+      SELECT ranked_posts.post_id, ranked_posts.favorites_count
+      FROM (
+        SELECT
+          counted_posts.post_id,
+          counted_posts.user_id,
+          counted_posts.favorites_count,
+          ROW_NUMBER() OVER (
+            PARTITION BY counted_posts.user_id
+            ORDER BY counted_posts.favorites_count DESC, counted_posts.created_at ASC, counted_posts.post_id ASC
+          ) AS user_post_rank
+        FROM (
+          SELECT
+            posts.id AS post_id,
+            posts.user_id,
+            posts.created_at,
+            COUNT(follows.id) AS favorites_count
+          FROM posts
+          INNER JOIN follows
+            ON follows.followable_type = 'Post'
+            AND follows.followable_id = posts.id
+            AND follows.follower_type = 'User'
+            AND follows.created_at >= :favorited_since
+          WHERE NOT EXISTS (
+            SELECT 1
+            FROM follows recent_author_favorites
+            INNER JOIN posts favorited_posts
+              ON favorited_posts.id = recent_author_favorites.followable_id
+            WHERE recent_author_favorites.followable_type = 'Post'
+              AND recent_author_favorites.follower_type = 'User'
+              AND recent_author_favorites.follower_id = posts.user_id
+              AND recent_author_favorites.created_at >= :reciprocal_since
+              AND favorited_posts.user_id = follows.follower_id
+          )
+          GROUP BY posts.id, posts.user_id, posts.created_at
+        ) counted_posts
+      ) ranked_posts
+      WHERE ranked_posts.user_post_rank = 1
+      ORDER BY ranked_posts.favorites_count DESC, ranked_posts.post_id ASC
+      LIMIT 30
+    SQL
+
+    popular_posts = ApplicationRecord.sanitize_sql(
+      [
+        popularity_sql,
+        { favorited_since: 1.day.ago, reciprocal_since: 7.days.ago }
+      ]
+    )
+
+    PopularPost.transaction do
+      PopularPost.delete_all
+
+      ApplicationRecord.connection.select_all(popular_posts).each.with_index(1) do |popular_post, position|
+        PopularPost.create!(
+          post_id: popular_post['post_id'],
+          position:,
+          favorites_count: popular_post['favorites_count']
+        )
+      end
+    end
+
+    Rails.logger.info "人気の歌を#{PopularPost.count}件集計しました"
+  end
+end


### PR DESCRIPTION
## 概要

人気の歌の掲載順を管理する `popular_posts` テーブルと、集計を更新する rake タスクを追加しました。

## 変更内容

- `popular_posts` テーブルを追加し、投稿・掲載順・集計対象いいね数を保存できるようにしました
- `PopularPost` モデルと `Post` からの関連を追加しました
- `popular_posts:refresh` タスクを追加し、既存データを物理削除してから最新の人気の歌を最大30件登録するようにしました
- 集計時に、投稿者が直近7日間にいいねした相手からのいいねを除外するようにしました
- 集計用に `follows` へ複合インデックスを追加しました

## 検証

- `docker compose run --rm app bin/rails db:migrate`
- `docker compose run --rm app bin/rails popular_posts:refresh`
- `docker compose run --rm app bin/rubocop`