### PR TITLE
「人気の歌」の掲載方法を変更する

### DIFF
--- a/app/controllers/posts/popular_controller.rb
+++ b/app/controllers/posts/popular_controller.rb
@@ -3,7 +3,7 @@
 class Posts::PopularController < ApplicationController
   def index
     @posts = Post.includes(:user, :followings)
-                 .joins(:popular_posts)
+                 .joins(:popular_post)
                  .order('popular_posts.position')
                  .page(params[:page])
   end

--- a/app/controllers/posts/popular_controller.rb
+++ b/app/controllers/posts/popular_controller.rb
@@ -3,14 +3,8 @@
 class Posts::PopularController < ApplicationController
   def index
     @posts = Post.includes(:user, :followings)
-                 .joins('INNER JOIN follows ON posts.id = follows.followable_id')
-                 .where(
-                   'follows.followable_type = :type and follows.created_at >= :time',
-                   { type: 'Post', time: 1.day.ago }
-                 )
-                 .group('posts.id')
-                 .order('count(follows.followable_id) desc')
-                 .order('posts.created_at')
+                 .joins('INNER JOIN popular_posts ON popular_posts.post_id = posts.id')
+                 .order('popular_posts.position')
                  .page(params[:page])
   end
 end

--- a/app/controllers/posts/popular_controller.rb
+++ b/app/controllers/posts/popular_controller.rb
@@ -3,7 +3,7 @@
 class Posts::PopularController < ApplicationController
   def index
     @posts = Post.includes(:user, :followings)
-                 .joins('INNER JOIN popular_posts ON popular_posts.post_id = posts.id')
+                 .joins(:popular_posts)
                  .order('popular_posts.position')
                  .page(params[:page])
   end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -6,7 +6,7 @@ class Post < ApplicationRecord
   acts_as_followable
 
   belongs_to :user
-  has_many :popular_posts, dependent: :destroy
+  has_one :popular_post, dependent: :destroy
 
   validates :tanka, presence: true, uniqueness: true, length: { minimum: 5, maximum: 1000 }
   validates :published_at, presence: true

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -6,6 +6,7 @@ class Post < ApplicationRecord
   acts_as_followable
 
   belongs_to :user
+  has_many :popular_posts, dependent: :destroy
 
   validates :tanka, presence: true, uniqueness: true, length: { minimum: 5, maximum: 1000 }
   validates :published_at, presence: true

--- a/app/views/about/index.html.erb
+++ b/app/views/about/index.html.erb
@@ -38,6 +38,12 @@
   </ul>
   <h4 class="mt-4">更新履歴</h4>
   <dl class="mt-4">
+    <dt><time>2026/04/25</time></dt>
+    <dd>
+      <ul class="ml">
+        <li>「人気の歌」の掲載方法を変更</li>
+      </ul>
+    </dd>
     <dt><time>2025/10/10</time></dt>
     <dd>
       <ul class="ml">


### PR DESCRIPTION
## 概要

- 「人気の歌」一覧を、その場で `follows` から集計する方式から `popular_posts` の掲載順データを参照する方式に変更しました。
- サイト案内の更新履歴に、2026/04/25 の変更内容を追加しました。

## 目的

PR #1040 で追加された `popular_posts` の集計結果に基づいて「人気の歌」を掲載するためです。

## 確認

- `docker compose run --rm app bin/rubocop`
- `docker compose run --rm app bin/rails test`

Resolves #1041