### PR TITLE
同じ歌人から複数いいねされる場合がある問題を解消する

### DIFF
--- a/app/views/about/index.html.erb
+++ b/app/views/about/index.html.erb
@@ -38,6 +38,12 @@
   </ul>
   <h4 class="mt-4">更新履歴</h4>
   <dl class="mt-4">
+    <dt><time>2026/04/26</time></dt>
+    <dd>
+      <ul class="ml">
+        <li>同じ歌人から複数いいねされる場合がある問題を解消</li>
+      </ul>
+    </dd>
     <dt><time>2026/04/25</time></dt>
     <dd>
       <ul class="ml">

--- a/db/migrate/20260426000000_add_unique_index_to_follows.rb
+++ b/db/migrate/20260426000000_add_unique_index_to_follows.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+class AddUniqueIndexToFollows < ActiveRecord::Migration[8.1]
+  def up
+    execute <<~SQL.squish
+      DELETE FROM follows
+      WHERE id IN (
+        SELECT id
+        FROM (
+          SELECT
+            id,
+            ROW_NUMBER() OVER (
+              PARTITION BY follower_id, follower_type, followable_id, followable_type
+              ORDER BY id
+            ) AS row_number
+          FROM follows
+        ) duplicate_follows
+        WHERE duplicate_follows.row_number > 1
+      )
+    SQL
+
+    add_index :follows,
+              %i[follower_id follower_type followable_id followable_type],
+              unique: true,
+              name: 'index_follows_on_follower_and_followable'
+  end
+
+  def down
+    remove_index :follows, name: 'index_follows_on_follower_and_followable'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_25_223957) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_26_000000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -26,6 +26,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_25_223957) do
     t.bigint "user_id", null: false
     t.index ["followable_id", "followable_type"], name: "fk_followables"
     t.index ["followable_type", "followable_id"], name: "index_follows_on_followable_type_and_followable_id"
+    t.index ["follower_id", "follower_type", "followable_id", "followable_type"], name: "index_follows_on_follower_and_followable", unique: true
     t.index ["follower_id", "follower_type"], name: "fk_follows"
     t.index ["follower_type", "follower_id"], name: "index_follows_on_follower_type_and_follower_id"
     t.index ["user_id"], name: "index_follows_on_user_id"


### PR DESCRIPTION
## 変更内容

- `follows` テーブルに、`follower_id` / `follower_type` / `followable_id` / `followable_type` の組み合わせのユニークインデックスを追加
- 既存データに同一組み合わせの重複がある場合、最初の1件を残して削除してからユニーク制約を追加
- サイト案内の更新履歴に 2026/04/26 の変更内容を追加

## 目的

同じ歌人から同じ対象に対して複数いいねされる場合がある問題を、DB側の制約で防ぎます。

## 動作確認

- `docker compose run --rm app bin/rails db:migrate`
- `docker compose run --rm app bin/rubocop`

Resolves #1045