### PR TITLE
ユーザーアイコン画像の表示を鮮明にする

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,7 +16,7 @@ class User < ApplicationRecord
 
   has_many :posts, dependent: :destroy
   has_attached_file :avatar,
-                    styles: { original: '75x75#', medium: '35x35#', small: '20x20#' },
+                    styles: { original: '150x150#', medium: '70x70#', small: '40x40#' },
                     convert_options: { all: '-strip' },
                     default_url: '//utakata.s3.amazonaws.com/:style/utakata.png'
 

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -21,7 +21,7 @@
       <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
         <div class="mb-3 mt-3">
           <%= f.label :avatar %><br />
-          <%= image_tag user.avatar.url, class: 'mb-2 rounded' %>
+          <%= image_tag user.avatar.url, class: 'mb-2 rounded', width: 75, height: 75 %>
           <%= f.file_field :avatar, accept: 'image/*', 'data-action': 'change->user#submit' %><br />
           <%= f.label :avatar, 'ファイル選択', class: 'btn btn-sm btn-primary' %>
         </div>

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -11,7 +11,7 @@
         </li>
         <li class="nav-item dropdown">
           <div class="nav-link dropdown-toggle" href="" id="navbarDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
-            <%= image_tag current_user.avatar.url(:medium), class: 'rounded' %>
+            <%= image_tag current_user.avatar.url(:medium), class: 'rounded', width: 35, height: 35 %>
           </div>
           <div class="dropdown-menu" aria-labelledby="navbarDropdown">
             <%= link_to 'マイページ', user_path(current_user), class: 'dropdown-item' %>

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -11,7 +11,7 @@
           <i class="bi bi-person-fill bi-vertical"></i>
         </div>
         <div>
-          <%= link_to (image_tag notification.follower.avatar.url(:small), class: 'rounded align-baseline'), user_path(notification.follower) %>
+          <%= link_to (image_tag notification.follower.avatar.url(:small), class: 'rounded align-baseline', width: 20, height: 20), user_path(notification.follower) %>
         </div>
         <div>
           <%= link_to notification.follower.name, user_path(notification.follower) %>さんにフォローされました
@@ -24,7 +24,7 @@
           <i class="bi bi-suit-heart-fill bi-vertical"></i>
         </div>
         <div>
-          <%= link_to (image_tag notification.follower.avatar.url(:small), class: 'rounded align-baseline'), user_path(notification.follower) %>
+          <%= link_to (image_tag notification.follower.avatar.url(:small), class: 'rounded align-baseline', width: 20, height: 20), user_path(notification.follower) %>
         </div>
         <div>
           <%= link_to notification.follower.name, user_path(notification.follower) %>さんがいいねしました「<%= link_to "#{notification.followable.tanka_text.slice(0, 5)}…", posts_post_followers_path(notification.followable) %>」

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -16,7 +16,7 @@
   <%= render 'favorites/favorites_count', post: post, size: 'sm' %>
   <% if show_avatar %>
     <div>
-      <%= link_to (image_tag post.user.avatar.url(:small), class: 'rounded align-baseline'), user_path(post.user) %>
+      <%= link_to (image_tag post.user.avatar.url(:small), class: 'rounded align-baseline', width: 20, height: 20), user_path(post.user) %>
     </div>
   <% end %>
 </div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -4,7 +4,7 @@
 <div class="mt-4 vertical serif mx-auto text-nowrap">
   <div class="vertical-flex">
     <div>
-      <%= link_to (image_tag @user.avatar.url(:medium), class: 'rounded align-baseline'), user_path(@user) %>
+      <%= link_to (image_tag @user.avatar.url(:medium), class: 'rounded align-baseline', width: 35, height: 35), user_path(@user) %>
     </div>
     <div>
       <%= link_to @user.name, user_path(@user), class: 'lg tanka-link' %>

--- a/app/views/users/_user.html.erb
+++ b/app/views/users/_user.html.erb
@@ -1,6 +1,6 @@
 <div class="vertical-flex p">
   <div>
-    <%= link_to (image_tag user.avatar.url(:medium), class: 'rounded align-baseline'), user_path(user) %>
+    <%= link_to (image_tag user.avatar.url(:medium), class: 'rounded align-baseline', width: 35, height: 35), user_path(user) %>
   </div>
   <div>
     <%= link_to user.name, user_path(user), class: 'tanka-link lg' %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -5,7 +5,7 @@
 <div class = "vertical serif mt-4 tanka-index text-nowrap">
   <div class="mx-4 vertical-flex">
     <div>
-      <%= image_tag @user.avatar.url(:original), class: 'rounded' %>
+      <%= image_tag @user.avatar.url(:original), class: 'rounded', width: 75, height: 75 %>
     </div>
     <div class="lg">
       <%= @user.name %>


### PR DESCRIPTION
## 変更内容

- ユーザーアイコンのPaperclip生成サイズを表示サイズの2倍に変更しました
  - small: 40x40
  - medium: 70x70
  - original: 150x150
- 各表示箇所では従来の見た目を維持するため、画像の表示サイズを明示しました
  - small表示: 20x20
  - medium表示: 35x35
  - original表示: 75x75

## 目的

高DPI環境でユーザーアイコン画像がぼやけて見えるため、新規アップロード画像から高解像度で生成されるようにします。既存画像の再生成は今回の対象外です。

## 検証

- `docker compose run --rm app bundle install`
- `docker compose run --rm app bin/rubocop`

Resolves #1051