### PR TITLE
DPR3倍に対応する

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,6 +1,12 @@
 # frozen_string_literal: true
 
 module ApplicationHelper
+  AVATAR_IMAGE_DISPLAY_SIZES = {
+    original: 75,
+    medium: 35,
+    small: 20
+  }.freeze
+
   def title(title)
     return 'Utakata - 短歌投稿サイト' if title.blank?
 
@@ -22,5 +28,11 @@ module ApplicationHelper
   def notifications_count
     notifications_count = Follow.where(user_id: current_user.id, read: false).count
     notifications_count.zero? ? nil : notifications_count
+  end
+
+  def avatar_image_tag(user, size, options = {})
+    display_size = AVATAR_IMAGE_DISPLAY_SIZES.fetch(size)
+
+    image_tag user.avatar.url(size), options.reverse_merge(width: display_size, height: display_size)
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -32,7 +32,8 @@ module ApplicationHelper
 
   def avatar_image_tag(user, size, options = {})
     display_size = AVATAR_IMAGE_DISPLAY_SIZES.fetch(size)
+    image_options = { width: display_size, height: display_size }.merge(options)
 
-    image_tag user.avatar.url(size), options.reverse_merge(width: display_size, height: display_size)
+    image_tag user.avatar.url(size), image_options
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,7 +16,7 @@ class User < ApplicationRecord
 
   has_many :posts, dependent: :destroy
   has_attached_file :avatar,
-                    styles: { original: '150x150#', medium: '70x70#', small: '40x40#' },
+                    styles: { original: '225x225#', medium: '105x105#', small: '60x60#' },
                     convert_options: { all: '-strip' },
                     default_url: '//utakata.s3.amazonaws.com/:style/utakata.png'
 

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -21,7 +21,7 @@
       <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
         <div class="mb-3 mt-3">
           <%= f.label :avatar %><br />
-          <%= image_tag user.avatar.url, class: 'mb-2 rounded', width: 75, height: 75 %>
+          <%= avatar_image_tag(user, :original, class: 'mb-2 rounded') %>
           <%= f.file_field :avatar, accept: 'image/*', 'data-action': 'change->user#submit' %><br />
           <%= f.label :avatar, 'ファイル選択', class: 'btn btn-sm btn-primary' %>
         </div>

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -11,7 +11,7 @@
         </li>
         <li class="nav-item dropdown">
           <div class="nav-link dropdown-toggle" href="" id="navbarDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
-            <%= image_tag current_user.avatar.url(:medium), class: 'rounded', width: 35, height: 35 %>
+            <%= avatar_image_tag(current_user, :medium, class: 'rounded') %>
           </div>
           <div class="dropdown-menu" aria-labelledby="navbarDropdown">
             <%= link_to 'マイページ', user_path(current_user), class: 'dropdown-item' %>

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -11,7 +11,7 @@
           <i class="bi bi-person-fill bi-vertical"></i>
         </div>
         <div>
-          <%= link_to (image_tag notification.follower.avatar.url(:small), class: 'rounded align-baseline', width: 20, height: 20), user_path(notification.follower) %>
+          <%= link_to avatar_image_tag(notification.follower, :small, class: 'rounded align-baseline'), user_path(notification.follower) %>
         </div>
         <div>
           <%= link_to notification.follower.name, user_path(notification.follower) %>さんにフォローされました
@@ -24,7 +24,7 @@
           <i class="bi bi-suit-heart-fill bi-vertical"></i>
         </div>
         <div>
-          <%= link_to (image_tag notification.follower.avatar.url(:small), class: 'rounded align-baseline', width: 20, height: 20), user_path(notification.follower) %>
+          <%= link_to avatar_image_tag(notification.follower, :small, class: 'rounded align-baseline'), user_path(notification.follower) %>
         </div>
         <div>
           <%= link_to notification.follower.name, user_path(notification.follower) %>さんがいいねしました「<%= link_to "#{notification.followable.tanka_text.slice(0, 5)}…", posts_post_followers_path(notification.followable) %>」

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -16,7 +16,7 @@
   <%= render 'favorites/favorites_count', post: post, size: 'sm' %>
   <% if show_avatar %>
     <div>
-      <%= link_to (image_tag post.user.avatar.url(:small), class: 'rounded align-baseline', width: 20, height: 20), user_path(post.user) %>
+      <%= link_to avatar_image_tag(post.user, :small, class: 'rounded align-baseline'), user_path(post.user) %>
     </div>
   <% end %>
 </div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -4,7 +4,7 @@
 <div class="mt-4 vertical serif mx-auto text-nowrap">
   <div class="vertical-flex">
     <div>
-      <%= link_to (image_tag @user.avatar.url(:medium), class: 'rounded align-baseline', width: 35, height: 35), user_path(@user) %>
+      <%= link_to avatar_image_tag(@user, :medium, class: 'rounded align-baseline'), user_path(@user) %>
     </div>
     <div>
       <%= link_to @user.name, user_path(@user), class: 'lg tanka-link' %>

--- a/app/views/users/_user.html.erb
+++ b/app/views/users/_user.html.erb
@@ -1,6 +1,6 @@
 <div class="vertical-flex p">
   <div>
-    <%= link_to (image_tag user.avatar.url(:medium), class: 'rounded align-baseline', width: 35, height: 35), user_path(user) %>
+    <%= link_to avatar_image_tag(user, :medium, class: 'rounded align-baseline'), user_path(user) %>
   </div>
   <div>
     <%= link_to user.name, user_path(user), class: 'tanka-link lg' %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -5,7 +5,7 @@
 <div class = "vertical serif mt-4 tanka-index text-nowrap">
   <div class="mx-4 vertical-flex">
     <div>
-      <%= image_tag @user.avatar.url(:original), class: 'rounded', width: 75, height: 75 %>
+      <%= avatar_image_tag(@user, :original, class: 'rounded') %>
     </div>
     <div class="lg">
       <%= @user.name %>


### PR DESCRIPTION
## 変更内容

- ユーザーアイコンのPaperclip生成サイズを表示サイズの3倍に変更しました
  - small: 60x60
  - medium: 105x105
  - original: 225x225

## 目的

高DPI環境でユーザーアイコン画像がまだぼやけて見えるため、新規アップロード画像からより高解像度で生成されるようにします。既存画像の再生成は今回の対象外です。

## 検証

- `docker compose run --rm app bin/rubocop`

Resolves #1053