### PR TITLE
短歌画像を生成する

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -4,6 +4,7 @@ import '@hotwired/turbo-rails';
 import { Application } from '@hotwired/stimulus';
 import { definitionsFromContext } from '@hotwired/stimulus-webpack-helpers';
 import 'bootstrap/js/dist/dropdown';
+import 'bootstrap/js/dist/modal';
 import 'bootstrap/js/dist/tab';
 import 'bootstrap-icons/font/bootstrap-icons.css';
 

--- a/app/assets/javascripts/controllers/tanka_image_controller.js
+++ b/app/assets/javascripts/controllers/tanka_image_controller.js
@@ -105,9 +105,10 @@ export default class extends Controller {
   }
 
   drawTanka(context) {
-    const characters = Array.from(this.tankaValue);
+    const units = this.parseTanka();
+    const tankaLength = units.reduce((length, unit) => length + unit.text.length, 0);
     const maxRows = 19;
-    const fontSize = characters.length > 55 ? 42 : 48;
+    const fontSize = tankaLength > 55 ? 42 : 48;
     const lineHeight = fontSize * 1.22;
     const columnGap = 88;
     const positions = [];
@@ -119,18 +120,20 @@ export default class extends Controller {
     context.textAlign = 'center';
     context.textBaseline = 'middle';
 
-    characters.forEach((character) => {
-      if (character === '\n' || row >= maxRows) {
+    units.forEach((unit) => {
+      if (unit.type === 'newline') {
+        column += 1;
+        row = 0;
+        return;
+      }
+
+      if (row + unit.rowSpan > maxRows) {
         column += 1;
         row = 0;
       }
 
-      if (character === '\n') {
-        return;
-      }
-
-      positions.push({ character, column, row });
-      row += 1;
+      positions.push({ ...unit, column, row });
+      row += unit.rowSpan;
     });
 
     if (positions.length === 0) {
@@ -146,8 +149,111 @@ export default class extends Controller {
       const x = firstColumnX - position.column * columnGap;
       const y = 250 + position.row * lineHeight;
 
-      context.fillText(position.character, x, y);
+      this.drawTankaUnit(context, position, x, y, fontSize, lineHeight);
     });
+  }
+
+  parseTanka() {
+    const template = document.createElement('template');
+    template.innerHTML = this.tankaValue;
+
+    return this.parseChildNodes(template.content.childNodes);
+  }
+
+  parseChildNodes(nodes) {
+    return Array.from(nodes).flatMap((node) => this.parseNode(node));
+  }
+
+  parseNode(node) {
+    if (node.nodeType === Node.TEXT_NODE) {
+      return Array.from(node.textContent).map((character) => {
+        if (character === '\n') {
+          return { type: 'newline', text: character, rowSpan: 0 };
+        }
+
+        return { type: 'character', text: character, rowSpan: 1 };
+      });
+    }
+
+    if (node.nodeType !== Node.ELEMENT_NODE) {
+      return [];
+    }
+
+    if (node.tagName === 'RUBY') {
+      const rt = node.querySelector('rt');
+      const baseText = Array.from(node.childNodes)
+        .filter((childNode) => !['RT', 'RP'].includes(childNode.tagName))
+        .map((childNode) => childNode.textContent)
+        .join('');
+
+      return [
+        {
+          type: 'ruby',
+          text: baseText,
+          ruby: rt?.textContent || '',
+          rowSpan: Math.max(Array.from(baseText).length, 1),
+        },
+      ];
+    }
+
+    if (node.classList.contains('tate')) {
+      return [{ type: 'upright', text: node.textContent, rowSpan: 1 }];
+    }
+
+    return this.parseChildNodes(node.childNodes);
+  }
+
+  drawTankaUnit(context, unit, x, y, fontSize, lineHeight) {
+    if (unit.type === 'ruby') {
+      this.drawRuby(context, unit, x, y, fontSize, lineHeight);
+      return;
+    }
+
+    if (unit.type === 'upright') {
+      this.drawUpright(context, unit.text, x, y, fontSize);
+      return;
+    }
+
+    context.fillText(unit.text, x, y);
+  }
+
+  drawRuby(context, unit, x, y, fontSize, lineHeight) {
+    const baseCharacters = Array.from(unit.text);
+    const rubyCharacters = Array.from(unit.ruby);
+    const rubyFontSize = Math.max(Math.round(fontSize * 0.34), 14);
+    const rubyX = x + fontSize * 0.62;
+
+    baseCharacters.forEach((character, index) => {
+      context.font = `${fontSize}px serif`;
+      context.fillText(character, x, y + index * lineHeight);
+    });
+
+    if (rubyCharacters.length === 0) {
+      return;
+    }
+
+    const baseHeight = (baseCharacters.length - 1) * lineHeight;
+    const rubyLineHeight =
+      baseCharacters.length > 1
+        ? baseHeight / Math.max(rubyCharacters.length - 1, 1)
+        : rubyFontSize * 0.9;
+    const rubyY =
+      y + baseHeight / 2 - ((rubyCharacters.length - 1) * rubyLineHeight) / 2;
+
+    rubyCharacters.forEach((character, index) => {
+      context.font = `${rubyFontSize}px serif`;
+      context.fillText(character, rubyX, rubyY + index * rubyLineHeight);
+    });
+
+    context.font = `${fontSize}px serif`;
+  }
+
+  drawUpright(context, text, x, y, fontSize) {
+    const uprightFontSize = Math.max(Math.round(fontSize * 0.72), 20);
+
+    context.font = `${uprightFontSize}px serif`;
+    context.fillText(text, x, y);
+    context.font = `${fontSize}px serif`;
   }
 
   drawMeta(context) {

--- a/app/assets/javascripts/controllers/tanka_image_controller.js
+++ b/app/assets/javascripts/controllers/tanka_image_controller.js
@@ -77,9 +77,9 @@ export default class extends Controller {
   drawTanka(context) {
     const units = this.parseTanka();
     const tankaLength = units.reduce((length, unit) => length + unit.text.length, 0);
-    const fontSize = tankaLength > 55 ? 42 : 48;
-    const lineHeight = fontSize * 1.22;
-    const verticalMargin = 150;
+    const fontSize = tankaLength > 55 ? 38 : 42;
+    const lineHeight = fontSize * 1.08;
+    const verticalMargin = 100;
     const maxRows =
       Math.floor(
         (context.canvas.height - verticalMargin * 2 - fontSize) / lineHeight,

--- a/app/assets/javascripts/controllers/tanka_image_controller.js
+++ b/app/assets/javascripts/controllers/tanka_image_controller.js
@@ -21,6 +21,7 @@ const TEMPLATES = {
 export default class extends Controller {
   static targets = [
     'canvas',
+    'dialog',
     'template',
     'textColor',
     'author',
@@ -33,6 +34,22 @@ export default class extends Controller {
 
   connect() {
     this.render();
+  }
+
+  open() {
+    if (!this.dialogTarget.open) {
+      this.dialogTarget.showModal();
+    }
+  }
+
+  close() {
+    this.dialogTarget.close();
+  }
+
+  closeOnBackdrop(event) {
+    if (event.target === this.dialogTarget) {
+      this.close();
+    }
   }
 
   selectTemplate() {

--- a/app/assets/javascripts/controllers/tanka_image_controller.js
+++ b/app/assets/javascripts/controllers/tanka_image_controller.js
@@ -73,32 +73,27 @@ export default class extends Controller {
 
   drawBackground(context, template) {
     const { width, height } = context.canvas;
-    const sideInset = 92;
-    const topInset = 118;
-    const bottomInset = 118;
+    const bandWidth = 190;
+    const lineInset = 64;
 
     context.fillStyle = template.background;
     context.fillRect(0, 0, width, height);
 
-    context.strokeStyle = template.accent;
-    context.lineWidth = 3;
-    context.beginPath();
-    context.moveTo(sideInset, topInset);
-    context.lineTo(sideInset, height - bottomInset);
-    context.moveTo(width - sideInset, topInset);
-    context.lineTo(width - sideInset, height - bottomInset);
-    context.stroke();
+    context.globalAlpha = 0.08;
+    context.fillStyle = template.accent;
+    context.fillRect(0, 0, bandWidth, height);
+    context.fillRect(width - bandWidth, 0, bandWidth, height);
+    context.globalAlpha = 1;
 
-    context.lineWidth = 1.5;
+    context.strokeStyle = template.accent;
+    context.lineWidth = 2;
     context.beginPath();
-    context.moveTo(sideInset + 24, topInset);
-    context.lineTo(sideInset + 150, topInset);
-    context.moveTo(width - sideInset - 150, topInset);
-    context.lineTo(width - sideInset - 24, topInset);
-    context.moveTo(sideInset + 24, height - bottomInset);
-    context.lineTo(sideInset + 150, height - bottomInset);
-    context.moveTo(width - sideInset - 150, height - bottomInset);
-    context.lineTo(width - sideInset - 24, height - bottomInset);
+    [lineInset, lineInset + 34, bandWidth - 36].forEach((x) => {
+      context.moveTo(x, 0);
+      context.lineTo(x, height);
+      context.moveTo(width - x, 0);
+      context.lineTo(width - x, height);
+    });
     context.stroke();
   }
 

--- a/app/assets/javascripts/controllers/tanka_image_controller.js
+++ b/app/assets/javascripts/controllers/tanka_image_controller.js
@@ -105,6 +105,7 @@ export default class extends Controller {
     const fontSize = characters.length > 55 ? 42 : 48;
     const lineHeight = fontSize * 1.22;
     const columnGap = 88;
+    const positions = [];
     let column = 0;
     let row = 0;
 
@@ -123,11 +124,24 @@ export default class extends Controller {
         return;
       }
 
-      const x = context.canvas.width - 250 - column * columnGap;
-      const y = 250 + row * lineHeight;
-
-      context.fillText(character, x, y);
+      positions.push({ character, column, row });
       row += 1;
+    });
+
+    if (positions.length === 0) {
+      return;
+    }
+
+    const totalColumns =
+      Math.max(...positions.map((position) => position.column)) + 1;
+    const firstColumnX =
+      context.canvas.width / 2 + ((totalColumns - 1) * columnGap) / 2;
+
+    positions.forEach((position) => {
+      const x = firstColumnX - position.column * columnGap;
+      const y = 250 + position.row * lineHeight;
+
+      context.fillText(position.character, x, y);
     });
   }
 

--- a/app/assets/javascripts/controllers/tanka_image_controller.js
+++ b/app/assets/javascripts/controllers/tanka_image_controller.js
@@ -73,28 +73,37 @@ export default class extends Controller {
 
   drawBackground(context, template) {
     const { width, height } = context.canvas;
-    const bandWidth = 190;
-    const lineInset = 64;
+    const washWidth = 280;
+    const ruleInset = 230;
 
     context.fillStyle = template.background;
     context.fillRect(0, 0, width, height);
 
-    context.globalAlpha = 0.08;
-    context.fillStyle = template.accent;
-    context.fillRect(0, 0, bandWidth, height);
-    context.fillRect(width - bandWidth, 0, bandWidth, height);
+    const leftWash = context.createLinearGradient(0, 0, washWidth, 0);
+    leftWash.addColorStop(0, template.accent);
+    leftWash.addColorStop(1, template.background);
+
+    const rightWash = context.createLinearGradient(width, 0, width - washWidth, 0);
+    rightWash.addColorStop(0, template.accent);
+    rightWash.addColorStop(1, template.background);
+
+    context.globalAlpha = 0.12;
+    context.fillStyle = leftWash;
+    context.fillRect(0, 0, washWidth, height);
+    context.fillStyle = rightWash;
+    context.fillRect(width - washWidth, 0, washWidth, height);
     context.globalAlpha = 1;
 
     context.strokeStyle = template.accent;
-    context.lineWidth = 2;
+    context.lineWidth = 1;
+    context.globalAlpha = 0.28;
     context.beginPath();
-    [lineInset, lineInset + 34, bandWidth - 36].forEach((x) => {
-      context.moveTo(x, 0);
-      context.lineTo(x, height);
-      context.moveTo(width - x, 0);
-      context.lineTo(width - x, height);
-    });
+    context.moveTo(ruleInset, 0);
+    context.lineTo(ruleInset, height);
+    context.moveTo(width - ruleInset, 0);
+    context.lineTo(width - ruleInset, height);
     context.stroke();
+    context.globalAlpha = 1;
   }
 
   drawTanka(context) {

--- a/app/assets/javascripts/controllers/tanka_image_controller.js
+++ b/app/assets/javascripts/controllers/tanka_image_controller.js
@@ -1,9 +1,33 @@
 import { Controller } from '@hotwired/stimulus';
 
+const PRESETS = {
+  white: {
+    background: '#ffffff',
+    text: '#20242a',
+  },
+  washi: {
+    background: '#f8f4ea',
+    text: '#20242a',
+  },
+  sora: {
+    background: '#e8f4fb',
+    text: '#163547',
+  },
+  wakakusa: {
+    background: '#edf6e8',
+    text: '#1f3d2b',
+  },
+  sumi: {
+    background: '#20242a',
+    text: '#f4efe7',
+  },
+};
+
 export default class extends Controller {
   static targets = [
     'backgroundColor',
     'canvas',
+    'preset',
     'textColor',
     'author',
   ];
@@ -14,6 +38,14 @@ export default class extends Controller {
   };
 
   connect() {
+    this.render();
+  }
+
+  selectPreset() {
+    const preset = PRESETS[this.presetTarget.value] || PRESETS.white;
+
+    this.backgroundColorTarget.value = preset.background;
+    this.textColorTarget.value = preset.text;
     this.render();
   }
 

--- a/app/assets/javascripts/controllers/tanka_image_controller.js
+++ b/app/assets/javascripts/controllers/tanka_image_controller.js
@@ -1,37 +1,9 @@
 import { Controller } from '@hotwired/stimulus';
 
-const TEMPLATES = {
-  white: {
-    background: '#ffffff',
-    accent: '#d8dde3',
-    text: '#20242a',
-  },
-  washi: {
-    background: '#f8f4ea',
-    accent: '#d7cbb8',
-    text: '#20242a',
-  },
-  sora: {
-    background: '#e8f4fb',
-    accent: '#8fc5de',
-    text: '#163547',
-  },
-  wakakusa: {
-    background: '#edf6e8',
-    accent: '#a7c79a',
-    text: '#1f3d2b',
-  },
-  sumi: {
-    background: '#20242a',
-    accent: '#6f7680',
-    text: '#f4efe7',
-  },
-};
-
 export default class extends Controller {
   static targets = [
+    'backgroundColor',
     'canvas',
-    'template',
     'textColor',
     'author',
   ];
@@ -45,19 +17,11 @@ export default class extends Controller {
     this.render();
   }
 
-  selectTemplate() {
-    const template = TEMPLATES[this.templateTarget.value] || TEMPLATES.washi;
-
-    this.textColorTarget.value = template.text;
-    this.render();
-  }
-
   render() {
     const canvas = this.canvasTarget;
     const context = canvas.getContext('2d');
-    const template = TEMPLATES[this.templateTarget.value] || TEMPLATES.washi;
 
-    this.drawBackground(context, template);
+    this.drawBackground(context);
     const tankaMetrics = this.drawTanka(context);
     this.drawMeta(context, tankaMetrics);
   }
@@ -71,39 +35,11 @@ export default class extends Controller {
     link.click();
   }
 
-  drawBackground(context, template) {
+  drawBackground(context) {
     const { width, height } = context.canvas;
-    const washWidth = 280;
-    const ruleInset = 230;
 
-    context.fillStyle = template.background;
+    context.fillStyle = this.backgroundColorTarget.value;
     context.fillRect(0, 0, width, height);
-
-    const leftWash = context.createLinearGradient(0, 0, washWidth, 0);
-    leftWash.addColorStop(0, template.accent);
-    leftWash.addColorStop(1, template.background);
-
-    const rightWash = context.createLinearGradient(width, 0, width - washWidth, 0);
-    rightWash.addColorStop(0, template.accent);
-    rightWash.addColorStop(1, template.background);
-
-    context.globalAlpha = 0.12;
-    context.fillStyle = leftWash;
-    context.fillRect(0, 0, washWidth, height);
-    context.fillStyle = rightWash;
-    context.fillRect(width - washWidth, 0, washWidth, height);
-    context.globalAlpha = 1;
-
-    context.strokeStyle = template.accent;
-    context.lineWidth = 1;
-    context.globalAlpha = 0.28;
-    context.beginPath();
-    context.moveTo(ruleInset, 0);
-    context.lineTo(ruleInset, height);
-    context.moveTo(width - ruleInset, 0);
-    context.lineTo(width - ruleInset, height);
-    context.stroke();
-    context.globalAlpha = 1;
   }
 
   drawTanka(context) {

--- a/app/assets/javascripts/controllers/tanka_image_controller.js
+++ b/app/assets/javascripts/controllers/tanka_image_controller.js
@@ -31,7 +31,6 @@ const TEMPLATES = {
 export default class extends Controller {
   static targets = [
     'canvas',
-    'dialog',
     'template',
     'textColor',
     'author',
@@ -44,22 +43,6 @@ export default class extends Controller {
 
   connect() {
     this.render();
-  }
-
-  open() {
-    if (!this.dialogTarget.open) {
-      this.dialogTarget.showModal();
-    }
-  }
-
-  close() {
-    this.dialogTarget.close();
-  }
-
-  closeOnBackdrop(event) {
-    if (event.target === this.dialogTarget) {
-      this.close();
-    }
   }
 
   selectTemplate() {

--- a/app/assets/javascripts/controllers/tanka_image_controller.js
+++ b/app/assets/javascripts/controllers/tanka_image_controller.js
@@ -73,13 +73,33 @@ export default class extends Controller {
 
   drawBackground(context, template) {
     const { width, height } = context.canvas;
+    const sideInset = 92;
+    const topInset = 118;
+    const bottomInset = 118;
 
     context.fillStyle = template.background;
     context.fillRect(0, 0, width, height);
 
     context.strokeStyle = template.accent;
-    context.lineWidth = 2;
-    context.strokeRect(70, 70, width - 140, height - 140);
+    context.lineWidth = 3;
+    context.beginPath();
+    context.moveTo(sideInset, topInset);
+    context.lineTo(sideInset, height - bottomInset);
+    context.moveTo(width - sideInset, topInset);
+    context.lineTo(width - sideInset, height - bottomInset);
+    context.stroke();
+
+    context.lineWidth = 1.5;
+    context.beginPath();
+    context.moveTo(sideInset + 24, topInset);
+    context.lineTo(sideInset + 150, topInset);
+    context.moveTo(width - sideInset - 150, topInset);
+    context.lineTo(width - sideInset - 24, topInset);
+    context.moveTo(sideInset + 24, height - bottomInset);
+    context.lineTo(sideInset + 150, height - bottomInset);
+    context.moveTo(width - sideInset - 150, height - bottomInset);
+    context.lineTo(width - sideInset - 24, height - bottomInset);
+    context.stroke();
   }
 
   drawTanka(context) {

--- a/app/assets/javascripts/controllers/tanka_image_controller.js
+++ b/app/assets/javascripts/controllers/tanka_image_controller.js
@@ -124,11 +124,8 @@ export default class extends Controller {
 
     const totalColumns =
       Math.max(...positions.map((position) => position.column)) + 1;
-    const totalRows =
-      Math.max(...positions.map((position) => position.row + position.rowSpan));
-    const textHeight = (totalRows - 1) * lineHeight + fontSize;
     const maxTextHeight = (maxRows - 1) * lineHeight + fontSize;
-    const firstRowY = (context.canvas.height - textHeight) / 2 + fontSize / 2;
+    const firstRowY = (context.canvas.height - maxTextHeight) / 2 + fontSize / 2;
     const firstColumnX =
       context.canvas.width / 2 + ((totalColumns - 1) * columnGap) / 2;
     const maxBottomY = (context.canvas.height + maxTextHeight) / 2;

--- a/app/assets/javascripts/controllers/tanka_image_controller.js
+++ b/app/assets/javascripts/controllers/tanka_image_controller.js
@@ -24,12 +24,10 @@ export default class extends Controller {
     'template',
     'textColor',
     'author',
-    'site',
   ];
 
   static values = {
     authorName: String,
-    siteName: String,
     tanka: String,
   };
 
@@ -116,7 +114,7 @@ export default class extends Controller {
     });
   }
 
-  drawMeta(context, template) {
+  drawMeta(context) {
     const x = 180;
 
     context.fillStyle = this.textColorTarget.value;
@@ -124,13 +122,7 @@ export default class extends Controller {
     context.textAlign = 'center';
     context.textBaseline = 'middle';
 
-    if (this.siteTarget.checked) {
-      context.fillStyle = template.accent;
-      this.drawVerticalText(context, this.siteNameValue, x, 1080, 34);
-    }
-
     if (this.authorTarget.checked) {
-      context.fillStyle = this.textColorTarget.value;
       this.drawVerticalText(context, this.authorNameValue, x, 1300, 38);
     }
   }

--- a/app/assets/javascripts/controllers/tanka_image_controller.js
+++ b/app/assets/javascripts/controllers/tanka_image_controller.js
@@ -80,16 +80,6 @@ export default class extends Controller {
     context.strokeStyle = template.accent;
     context.lineWidth = 2;
     context.strokeRect(70, 70, width - 140, height - 140);
-
-    context.globalAlpha = 0.08;
-    for (let index = 0; index < 28; index += 1) {
-      const y = 130 + index * 52;
-      context.beginPath();
-      context.moveTo(120, y);
-      context.lineTo(width - 120, y + 18);
-      context.stroke();
-    }
-    context.globalAlpha = 1;
   }
 
   drawTanka(context) {

--- a/app/assets/javascripts/controllers/tanka_image_controller.js
+++ b/app/assets/javascripts/controllers/tanka_image_controller.js
@@ -58,8 +58,8 @@ export default class extends Controller {
     const template = TEMPLATES[this.templateTarget.value] || TEMPLATES.washi;
 
     this.drawBackground(context, template);
-    this.drawTanka(context);
-    this.drawMeta(context, template);
+    const tankaMetrics = this.drawTanka(context);
+    this.drawMeta(context, tankaMetrics);
   }
 
   download() {
@@ -85,9 +85,13 @@ export default class extends Controller {
   drawTanka(context) {
     const units = this.parseTanka();
     const tankaLength = units.reduce((length, unit) => length + unit.text.length, 0);
-    const maxRows = 19;
     const fontSize = tankaLength > 55 ? 42 : 48;
     const lineHeight = fontSize * 1.22;
+    const verticalMargin = 150;
+    const maxRows =
+      Math.floor(
+        (context.canvas.height - verticalMargin * 2 - fontSize) / lineHeight,
+      ) + 1;
     const columnGap = 88;
     const positions = [];
     let column = 0;
@@ -115,20 +119,27 @@ export default class extends Controller {
     });
 
     if (positions.length === 0) {
-      return;
+      return null;
     }
 
     const totalColumns =
       Math.max(...positions.map((position) => position.column)) + 1;
+    const totalRows =
+      Math.max(...positions.map((position) => position.row + position.rowSpan));
+    const textHeight = (totalRows - 1) * lineHeight + fontSize;
+    const firstRowY = (context.canvas.height - textHeight) / 2 + fontSize / 2;
     const firstColumnX =
       context.canvas.width / 2 + ((totalColumns - 1) * columnGap) / 2;
+    const bottomY = firstRowY + (totalRows - 1) * lineHeight + fontSize / 2;
 
     positions.forEach((position) => {
       const x = firstColumnX - position.column * columnGap;
-      const y = 250 + position.row * lineHeight;
+      const y = firstRowY + position.row * lineHeight;
 
       this.drawTankaUnit(context, position, x, y, fontSize, lineHeight);
     });
+
+    return { bottomY };
   }
 
   parseTanka() {
@@ -234,16 +245,24 @@ export default class extends Controller {
     context.font = `${fontSize}px serif`;
   }
 
-  drawMeta(context) {
+  drawMeta(context, tankaMetrics) {
     const x = 180;
+    const fontSize = 30;
+    const lineHeight = 38;
+    const authorCharacters = Array.from(this.authorNameValue);
+    const authorStartY =
+      tankaMetrics === null
+        ? 1300
+        : tankaMetrics.bottomY -
+          (Math.max(authorCharacters.length - 1, 0) * lineHeight + fontSize / 2);
 
     context.fillStyle = this.textColorTarget.value;
-    context.font = '30px serif';
+    context.font = `${fontSize}px serif`;
     context.textAlign = 'center';
     context.textBaseline = 'middle';
 
     if (this.authorTarget.checked) {
-      this.drawVerticalText(context, this.authorNameValue, x, 1300, 38);
+      this.drawVerticalText(context, this.authorNameValue, x, authorStartY, lineHeight);
     }
   }
 

--- a/app/assets/javascripts/controllers/tanka_image_controller.js
+++ b/app/assets/javascripts/controllers/tanka_image_controller.js
@@ -67,6 +67,12 @@ export default class extends Controller {
     link.click();
   }
 
+  releaseModalFocus(event) {
+    if (event.currentTarget.contains(document.activeElement)) {
+      document.activeElement.blur();
+    }
+  }
+
   drawBackground(context) {
     const { width, height } = context.canvas;
 

--- a/app/assets/javascripts/controllers/tanka_image_controller.js
+++ b/app/assets/javascripts/controllers/tanka_image_controller.js
@@ -16,6 +16,11 @@ const TEMPLATES = {
     accent: '#8fc5de',
     text: '#163547',
   },
+  wakakusa: {
+    background: '#edf6e8',
+    accent: '#a7c79a',
+    text: '#1f3d2b',
+  },
   sumi: {
     background: '#20242a',
     accent: '#6f7680',

--- a/app/assets/javascripts/controllers/tanka_image_controller.js
+++ b/app/assets/javascripts/controllers/tanka_image_controller.js
@@ -76,10 +76,10 @@ export default class extends Controller {
 
   drawTanka(context) {
     const units = this.parseTanka();
-    const tankaLength = units.reduce((length, unit) => length + unit.text.length, 0);
-    const fontSize = tankaLength > 55 ? 38 : 42;
-    const lineHeight = fontSize * 1.08;
+    const lineHeightRatio = 1.08;
     const verticalMargin = 100;
+    const fontSize = this.calculateFontSize(context, units, verticalMargin, lineHeightRatio);
+    const lineHeight = fontSize * lineHeightRatio;
     const maxRows =
       Math.floor(
         (context.canvas.height - verticalMargin * 2 - fontSize) / lineHeight,
@@ -132,6 +132,41 @@ export default class extends Controller {
     });
 
     return { bottomY };
+  }
+
+  calculateFontSize(context, units, verticalMargin, lineHeightRatio) {
+    const maxRowsForSingleColumn = 30;
+    const minFontSize = 38;
+    const maxFontSize = 58;
+    const availableHeight = context.canvas.height - verticalMargin * 2;
+    const rowCount = Math.min(
+      this.maxRowsWithoutWrapping(units),
+      maxRowsForSingleColumn,
+    );
+    const fittedFontSize =
+      availableHeight / (1 + (rowCount - 1) * lineHeightRatio);
+
+    return Math.max(
+      minFontSize,
+      Math.min(Math.floor(fittedFontSize), maxFontSize),
+    );
+  }
+
+  maxRowsWithoutWrapping(units) {
+    let maxRows = 0;
+    let rows = 0;
+
+    units.forEach((unit) => {
+      if (unit.type === 'newline') {
+        maxRows = Math.max(maxRows, rows);
+        rows = 0;
+        return;
+      }
+
+      rows += unit.rowSpan;
+    });
+
+    return Math.max(maxRows, rows, 1);
   }
 
   parseTanka() {

--- a/app/assets/javascripts/controllers/tanka_image_controller.js
+++ b/app/assets/javascripts/controllers/tanka_image_controller.js
@@ -1,6 +1,11 @@
 import { Controller } from '@hotwired/stimulus';
 
 const TEMPLATES = {
+  white: {
+    background: '#ffffff',
+    accent: '#d8dde3',
+    text: '#20242a',
+  },
   washi: {
     background: '#f8f4ea',
     accent: '#d7cbb8',

--- a/app/assets/javascripts/controllers/tanka_image_controller.js
+++ b/app/assets/javascripts/controllers/tanka_image_controller.js
@@ -1,0 +1,143 @@
+import { Controller } from '@hotwired/stimulus';
+
+const TEMPLATES = {
+  washi: {
+    background: '#f8f4ea',
+    accent: '#d7cbb8',
+    text: '#20242a',
+  },
+  sora: {
+    background: '#e8f4fb',
+    accent: '#8fc5de',
+    text: '#163547',
+  },
+  sumi: {
+    background: '#20242a',
+    accent: '#6f7680',
+    text: '#f4efe7',
+  },
+};
+
+export default class extends Controller {
+  static targets = [
+    'canvas',
+    'template',
+    'textColor',
+    'author',
+    'site',
+  ];
+
+  static values = {
+    authorName: String,
+    siteName: String,
+    tanka: String,
+  };
+
+  connect() {
+    this.render();
+  }
+
+  selectTemplate() {
+    const template = TEMPLATES[this.templateTarget.value] || TEMPLATES.washi;
+
+    this.textColorTarget.value = template.text;
+    this.render();
+  }
+
+  render() {
+    const canvas = this.canvasTarget;
+    const context = canvas.getContext('2d');
+    const template = TEMPLATES[this.templateTarget.value] || TEMPLATES.washi;
+
+    this.drawBackground(context, template);
+    this.drawTanka(context);
+    this.drawMeta(context, template);
+  }
+
+  download() {
+    this.render();
+
+    const link = document.createElement('a');
+    link.download = 'utakata-tanka.png';
+    link.href = this.canvasTarget.toDataURL('image/png');
+    link.click();
+  }
+
+  drawBackground(context, template) {
+    const { width, height } = context.canvas;
+
+    context.fillStyle = template.background;
+    context.fillRect(0, 0, width, height);
+
+    context.strokeStyle = template.accent;
+    context.lineWidth = 2;
+    context.strokeRect(70, 70, width - 140, height - 140);
+
+    context.globalAlpha = 0.08;
+    for (let index = 0; index < 28; index += 1) {
+      const y = 130 + index * 52;
+      context.beginPath();
+      context.moveTo(120, y);
+      context.lineTo(width - 120, y + 18);
+      context.stroke();
+    }
+    context.globalAlpha = 1;
+  }
+
+  drawTanka(context) {
+    const characters = Array.from(this.tankaValue);
+    const maxRows = 19;
+    const fontSize = characters.length > 55 ? 42 : 48;
+    const lineHeight = fontSize * 1.22;
+    const columnGap = 88;
+    let column = 0;
+    let row = 0;
+
+    context.fillStyle = this.textColorTarget.value;
+    context.font = `${fontSize}px serif`;
+    context.textAlign = 'center';
+    context.textBaseline = 'middle';
+
+    characters.forEach((character) => {
+      if (character === '\n' || row >= maxRows) {
+        column += 1;
+        row = 0;
+      }
+
+      if (character === '\n') {
+        return;
+      }
+
+      const x = context.canvas.width - 250 - column * columnGap;
+      const y = 250 + row * lineHeight;
+
+      context.fillText(character, x, y);
+      row += 1;
+    });
+  }
+
+  drawMeta(context, template) {
+    const x = 180;
+
+    context.fillStyle = this.textColorTarget.value;
+    context.font = '30px serif';
+    context.textAlign = 'center';
+    context.textBaseline = 'middle';
+
+    if (this.siteTarget.checked) {
+      context.fillStyle = template.accent;
+      this.drawVerticalText(context, this.siteNameValue, x, 1080, 34);
+    }
+
+    if (this.authorTarget.checked) {
+      context.fillStyle = this.textColorTarget.value;
+      this.drawVerticalText(context, this.authorNameValue, x, 1300, 38);
+    }
+  }
+
+  drawVerticalText(context, text, x, y, lineHeight) {
+    Array.from(text).forEach((character, index) => {
+      context.fillText(character, x, y + index * lineHeight);
+    });
+  }
+}

--- a/app/assets/javascripts/controllers/tanka_image_controller.js
+++ b/app/assets/javascripts/controllers/tanka_image_controller.js
@@ -124,11 +124,13 @@ export default class extends Controller {
 
     const totalColumns =
       Math.max(...positions.map((position) => position.column)) + 1;
-    const maxTextHeight = (maxRows - 1) * lineHeight + fontSize;
-    const firstRowY = (context.canvas.height - maxTextHeight) / 2 + fontSize / 2;
+    const totalRows =
+      Math.max(...positions.map((position) => position.row + position.rowSpan));
+    const textHeight = (totalRows - 1) * lineHeight + fontSize;
+    const firstRowY = (context.canvas.height - textHeight) / 2 + fontSize / 2;
     const firstColumnX =
       context.canvas.width / 2 + ((totalColumns - 1) * columnGap) / 2;
-    const maxBottomY = (context.canvas.height + maxTextHeight) / 2;
+    const bottomY = firstRowY + (totalRows - 1) * lineHeight + fontSize / 2;
 
     positions.forEach((position) => {
       const x = firstColumnX - position.column * columnGap;
@@ -137,7 +139,7 @@ export default class extends Controller {
       this.drawTankaUnit(context, position, x, y, fontSize, lineHeight);
     });
 
-    return { bottomY: maxBottomY };
+    return { bottomY };
   }
 
   parseTanka() {

--- a/app/assets/javascripts/controllers/tanka_image_controller.js
+++ b/app/assets/javascripts/controllers/tanka_image_controller.js
@@ -127,10 +127,11 @@ export default class extends Controller {
     const totalRows =
       Math.max(...positions.map((position) => position.row + position.rowSpan));
     const textHeight = (totalRows - 1) * lineHeight + fontSize;
+    const maxTextHeight = (maxRows - 1) * lineHeight + fontSize;
     const firstRowY = (context.canvas.height - textHeight) / 2 + fontSize / 2;
     const firstColumnX =
       context.canvas.width / 2 + ((totalColumns - 1) * columnGap) / 2;
-    const bottomY = firstRowY + (totalRows - 1) * lineHeight + fontSize / 2;
+    const maxBottomY = (context.canvas.height + maxTextHeight) / 2;
 
     positions.forEach((position) => {
       const x = firstColumnX - position.column * columnGap;
@@ -139,7 +140,7 @@ export default class extends Controller {
       this.drawTankaUnit(context, position, x, y, fontSize, lineHeight);
     });
 
-    return { bottomY };
+    return { bottomY: maxBottomY };
   }
 
   parseTanka() {

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -372,7 +372,48 @@ label {
 }
 
 @media (max-width: 767px) {
+  .modal-body {
+    padding: 0.75rem;
+  }
+
   .tanka-image__layout {
     grid-template-columns: 1fr;
+    gap: 0.75rem;
+  }
+
+  .tanka-image__controls {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 0.75rem;
+    align-items: end;
+  }
+
+  .tanka-image__control label {
+    margin-bottom: 0.25rem;
+    font-size: 0.9rem;
+  }
+
+  .tanka-image__control .form-control {
+    min-height: 38px;
+  }
+
+  .tanka-image__control .form-control-color {
+    width: 100%;
+    max-width: none;
+    padding: 0.25rem;
+  }
+
+  .tanka-image__control--author {
+    display: flex;
+    align-items: center;
+    min-height: 38px;
+    margin-bottom: 0;
+  }
+
+  .tanka-image__control--author .form-check-label {
+    margin-bottom: 0;
+  }
+
+  .tanka-image__control--download {
+    grid-column: 1 / -1;
   }
 }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -299,6 +299,20 @@ label {
   gap: 1rem;
 }
 
+.tanka-image__control-group {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.tanka-image__control-group-title {
+  font-weight: 600;
+}
+
+.tanka-image__control-row {
+  display: grid;
+  gap: 1rem;
+}
+
 .tate {
   -webkit-text-combine: horizontal;
   -ms-text-combine-horizontal: all;
@@ -382,7 +396,19 @@ label {
   }
 
   .tanka-image__controls {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 0.75rem;
+  }
+
+  .tanka-image__control-group {
+    gap: 0.35rem;
+  }
+
+  .tanka-image__control-group-title {
+    font-size: 0.85rem;
+  }
+
+  .tanka-image__control-row {
+    grid-template-columns: minmax(0, 1fr) minmax(54px, 0.34fr);
     gap: 0.75rem;
     align-items: end;
   }
@@ -409,11 +435,11 @@ label {
     margin-bottom: 0;
   }
 
-  .tanka-image__control--author .form-check-label {
-    margin-bottom: 0;
+  .tanka-image__control--author.form-check {
+    padding-left: 1.4rem;
   }
 
-  .tanka-image__control--download {
-    grid-column: 1 / -1;
+  .tanka-image__control--author .form-check-label {
+    margin-bottom: 0;
   }
 }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -419,17 +419,11 @@ label {
   }
 
   .tanka-image__control--author {
-    display: flex;
-    align-items: center;
-    min-height: 38px;
-    padding: 0.45rem 0.75rem;
     margin-bottom: 0;
-    border: 1px solid #dee2e6;
-    border-radius: var(--bs-border-radius);
   }
 
   .tanka-image__control--author.form-check {
-    padding-left: 2rem;
+    padding-left: 1.5rem;
   }
 
   .tanka-image__control--author .form-check-label {

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -299,15 +299,6 @@ label {
   gap: 1rem;
 }
 
-.tanka-image__control-group {
-  display: grid;
-  gap: 0.5rem;
-}
-
-.tanka-image__control-group-title {
-  font-weight: 600;
-}
-
 .tanka-image__control-row {
   display: grid;
   gap: 1rem;
@@ -401,14 +392,6 @@ label {
 
   .tanka-image__controls {
     gap: 0.75rem;
-  }
-
-  .tanka-image__control-group {
-    gap: 0.35rem;
-  }
-
-  .tanka-image__control-group-title {
-    font-size: 0.85rem;
   }
 
   .tanka-image__control-row {

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -313,6 +313,10 @@ label {
   gap: 1rem;
 }
 
+.tanka-image__control-row--colors {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
 .tate {
   -webkit-text-combine: horizontal;
   -ms-text-combine-horizontal: all;
@@ -408,9 +412,12 @@ label {
   }
 
   .tanka-image__control-row {
-    grid-template-columns: minmax(0, 1fr) minmax(54px, 0.34fr);
     gap: 0.75rem;
     align-items: end;
+  }
+
+  .tanka-image__control-row--colors {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
   .tanka-image__control label {
@@ -432,11 +439,14 @@ label {
     display: flex;
     align-items: center;
     min-height: 38px;
+    padding: 0.45rem 0.75rem;
     margin-bottom: 0;
+    border: 1px solid #dee2e6;
+    border-radius: var(--bs-border-radius);
   }
 
   .tanka-image__control--author.form-check {
-    padding-left: 1.4rem;
+    padding-left: 2rem;
   }
 
   .tanka-image__control--author .form-check-label {

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -276,32 +276,6 @@ label {
   color: $utakata-blue-hover;
 }
 
-.tanka-image-dialog {
-  width: min(900px, calc(100vw - 2rem));
-  max-height: calc(100vh - 2rem);
-  padding: 0;
-  border: 1px solid #dee2e6;
-  border-radius: var(--bs-border-radius);
-}
-
-.tanka-image-dialog::backdrop {
-  background-color: rgba(0, 0, 0, 0.45);
-}
-
-.tanka-image-dialog__header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 1rem;
-  border-bottom: 1px solid #dee2e6;
-}
-
-.tanka-image-dialog__body {
-  max-height: calc(100vh - 8rem);
-  padding: 1rem;
-  overflow: auto;
-}
-
 .tanka-image {
   width: 100%;
 }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -264,14 +264,51 @@ label {
   color: gray;
 }
 
+.tanka-image-trigger {
+  padding: 0;
+  color: $utakata-blue;
+  background: transparent;
+  border: 0;
+  line-height: 1;
+}
+
+.tanka-image-trigger:hover {
+  color: $utakata-blue-hover;
+}
+
+.tanka-image-dialog {
+  width: min(900px, calc(100vw - 2rem));
+  max-height: calc(100vh - 2rem);
+  padding: 0;
+  border: 1px solid #dee2e6;
+  border-radius: var(--bs-border-radius);
+}
+
+.tanka-image-dialog::backdrop {
+  background-color: rgba(0, 0, 0, 0.45);
+}
+
+.tanka-image-dialog__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem;
+  border-bottom: 1px solid #dee2e6;
+}
+
+.tanka-image-dialog__body {
+  max-height: calc(100vh - 8rem);
+  padding: 1rem;
+  overflow: auto;
+}
+
 .tanka-image {
-  max-width: 980px;
-  padding: 0 1rem;
+  width: 100%;
 }
 
 .tanka-image__layout {
   display: grid;
-  grid-template-columns: minmax(240px, 360px) minmax(220px, 1fr);
+  grid-template-columns: minmax(220px, 360px) minmax(220px, 1fr);
   gap: 1.5rem;
   align-items: start;
 }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -264,6 +264,30 @@ label {
   color: gray;
 }
 
+.tanka-image {
+  max-width: 980px;
+  padding: 0 1rem;
+}
+
+.tanka-image__layout {
+  display: grid;
+  grid-template-columns: minmax(240px, 360px) minmax(220px, 1fr);
+  gap: 1.5rem;
+  align-items: start;
+}
+
+.tanka-image__canvas {
+  width: 100%;
+  aspect-ratio: 3 / 4;
+  border: 1px solid #dee2e6;
+  background-color: #f8f4ea;
+}
+
+.tanka-image__controls {
+  display: grid;
+  gap: 1rem;
+}
+
 .tate {
   -webkit-text-combine: horizontal;
   -ms-text-combine-horizontal: all;
@@ -334,4 +358,10 @@ label {
   display: flex;
   align-items: center;
   gap: 0.5rem;
+}
+
+@media (max-width: 767px) {
+  .tanka-image__layout {
+    grid-template-columns: 1fr;
+  }
 }

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -108,7 +108,7 @@
               <button type="button"
                       class="btn btn-primary"
                       data-action="tanka-image#download">
-                PNGをダウンロード
+                画像をダウンロード
               </button>
             </div>
           </div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -74,7 +74,7 @@
                       aria-label="短歌画像のプレビュー"></canvas>
 
               <div class="tanka-image__controls">
-                <div>
+                <div class="tanka-image__control tanka-image__control--preset">
                   <label for="tanka-image-preset">おすすめ背景</label>
                   <select id="tanka-image-preset"
                           class="form-control"
@@ -88,7 +88,7 @@
                   </select>
                 </div>
 
-                <div>
+                <div class="tanka-image__control">
                   <label for="tanka-image-background-color">背景色</label>
                   <input id="tanka-image-background-color"
                          type="color"
@@ -98,7 +98,7 @@
                          data-action="input->tanka-image#render">
                 </div>
 
-                <div>
+                <div class="tanka-image__control">
                   <label for="tanka-image-text-color">文字色</label>
                   <input id="tanka-image-text-color"
                          type="color"
@@ -108,7 +108,7 @@
                          data-action="input->tanka-image#render">
                 </div>
 
-                <div class="form-check">
+                <div class="tanka-image__control tanka-image__control--author form-check">
                   <input id="tanka-image-author"
                          type="checkbox"
                          class="form-check-input"
@@ -119,7 +119,7 @@
                 </div>
 
                 <button type="button"
-                        class="btn btn-primary"
+                        class="tanka-image__control--download btn btn-primary"
                         data-action="tanka-image#download">
                   画像をダウンロード
                 </button>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -77,11 +77,11 @@
                         class="form-control"
                         data-tanka-image-target="template"
                         data-action="change->tanka-image#selectTemplate">
-                  <option value="white">白</option>
+                  <option value="white">白地</option>
                   <option value="washi">和紙</option>
-                  <option value="sora">空色</option>
+                  <option value="sora">空</option>
                   <option value="wakakusa">若草</option>
-                  <option value="sumi">墨色</option>
+                  <option value="sumi">墨</option>
                 </select>
               </div>
 

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -20,15 +20,6 @@
           <i class="lg bi bi-twitter bi-vertical"></i>
         </a>
       </div>
-      <div class="my-1">
-        <button type="button"
-                class="tanka-image-trigger"
-                data-bs-toggle="modal"
-                data-bs-target="#tanka-image-modal"
-                aria-label="短歌画像">
-          <i class="lg bi bi-card-image bi-vertical"></i>
-        </button>
-      </div>
       <% if current_user && current_user.id != @post.user_id %>
         <% if current_user.following?(@post) %>
           <%= render 'favorites/unlike', post: @post, size: 'lg' %>
@@ -42,6 +33,15 @@
       <% end %>
       <%= render 'favorites/favorites_count', post: @post, size: 'lg' %>
       <% if current_user && current_user.id == @user.id %>
+        <div class="my-1">
+          <button type="button"
+                  class="tanka-image-trigger"
+                  data-bs-toggle="modal"
+                  data-bs-target="#tanka-image-modal"
+                  aria-label="短歌画像">
+            <i class="lg bi bi-card-image bi-vertical"></i>
+          </button>
+        </div>
         <div class="my-1">
           <%= link_to content_tag(:i, '', class: "lg bi bi-pencil bi-vertical"), edit_post_path(@post) %>
         </div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -74,48 +74,58 @@
                       aria-label="短歌画像のプレビュー"></canvas>
 
               <div class="tanka-image__controls">
-                <div class="tanka-image__control tanka-image__control--preset">
-                  <label for="tanka-image-preset">おすすめ背景</label>
-                  <select id="tanka-image-preset"
-                          class="form-control"
-                          data-tanka-image-target="preset"
-                          data-action="change->tanka-image#selectPreset">
-                    <option value="white">白地</option>
-                    <option value="washi">和紙</option>
-                    <option value="sora">空</option>
-                    <option value="wakakusa">若草</option>
-                    <option value="sumi">墨</option>
-                  </select>
+                <div class="tanka-image__control-group">
+                  <div class="tanka-image__control-group-title">背景</div>
+                  <div class="tanka-image__control-row">
+                    <div class="tanka-image__control tanka-image__control--preset">
+                      <label for="tanka-image-preset">おすすめ</label>
+                      <select id="tanka-image-preset"
+                              class="form-control"
+                              data-tanka-image-target="preset"
+                              data-action="change->tanka-image#selectPreset">
+                        <option value="white">白地</option>
+                        <option value="washi">和紙</option>
+                        <option value="sora">空</option>
+                        <option value="wakakusa">若草</option>
+                        <option value="sumi">墨</option>
+                      </select>
+                    </div>
+
+                    <div class="tanka-image__control tanka-image__control--color">
+                      <label for="tanka-image-background-color">色</label>
+                      <input id="tanka-image-background-color"
+                             type="color"
+                             class="form-control form-control-color"
+                             value="#ffffff"
+                             data-tanka-image-target="backgroundColor"
+                             data-action="input->tanka-image#render">
+                    </div>
+                  </div>
                 </div>
 
-                <div class="tanka-image__control">
-                  <label for="tanka-image-background-color">背景色</label>
-                  <input id="tanka-image-background-color"
-                         type="color"
-                         class="form-control form-control-color"
-                         value="#ffffff"
-                         data-tanka-image-target="backgroundColor"
-                         data-action="input->tanka-image#render">
-                </div>
+                <div class="tanka-image__control-group">
+                  <div class="tanka-image__control-group-title">文字</div>
+                  <div class="tanka-image__control-row">
+                    <div class="tanka-image__control tanka-image__control--color">
+                      <label for="tanka-image-text-color">色</label>
+                      <input id="tanka-image-text-color"
+                             type="color"
+                             class="form-control form-control-color"
+                             value="#20242a"
+                             data-tanka-image-target="textColor"
+                             data-action="input->tanka-image#render">
+                    </div>
 
-                <div class="tanka-image__control">
-                  <label for="tanka-image-text-color">文字色</label>
-                  <input id="tanka-image-text-color"
-                         type="color"
-                         class="form-control form-control-color"
-                         value="#20242a"
-                         data-tanka-image-target="textColor"
-                         data-action="input->tanka-image#render">
-                </div>
-
-                <div class="tanka-image__control tanka-image__control--author form-check">
-                  <input id="tanka-image-author"
-                         type="checkbox"
-                         class="form-check-input"
-                         checked
-                         data-tanka-image-target="author"
-                         data-action="change->tanka-image#render">
-                  <label class="form-check-label" for="tanka-image-author">作者名を表示</label>
+                    <div class="tanka-image__control tanka-image__control--author form-check">
+                      <input id="tanka-image-author"
+                             type="checkbox"
+                             class="form-check-input"
+                             checked
+                             data-tanka-image-target="author"
+                             data-action="change->tanka-image#render">
+                      <label class="form-check-label" for="tanka-image-author">作者名を表示</label>
+                    </div>
+                  </div>
                 </div>
 
                 <button type="button"

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -69,8 +69,8 @@
           <div class="tanka-image">
             <div class="tanka-image__layout">
               <canvas class="tanka-image__canvas"
-                      width="1200"
-                      height="1600"
+                      width="1080"
+                      height="1440"
                       data-tanka-image-target="canvas"
                       aria-label="短歌画像のプレビュー"></canvas>
 

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -2,7 +2,7 @@
 <% @description = "#{@user.name}の短歌：#{@tanka}" %>
 
 <div data-controller="tanka-image"
-     data-tanka-image-tanka-value="<%= @post.tanka_text %>"
+     data-tanka-image-tanka-value="<%= @post.tanka %>"
      data-tanka-image-author-name-value="<%= @user.name %>">
   <div class="mt-4 vertical serif mx-auto text-nowrap">
     <div class="vertical-flex">

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -77,6 +77,7 @@
                         class="form-control"
                         data-tanka-image-target="template"
                         data-action="change->tanka-image#selectTemplate">
+                  <option value="white">白</option>
                   <option value="washi">和紙</option>
                   <option value="sora">空色</option>
                   <option value="sumi">墨色</option>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -80,6 +80,7 @@
                   <option value="white">白</option>
                   <option value="washi">和紙</option>
                   <option value="sora">空色</option>
+                  <option value="wakakusa">若草</option>
                   <option value="sumi">墨色</option>
                 </select>
               </div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -52,7 +52,7 @@
     <p class="lg"><%= @post.tanka.html_safe %></p>
   </div>
 
-  <dialog class="tanka-image-dialog horizontal serif"
+  <dialog class="tanka-image-dialog horizontal"
           aria-labelledby="tanka-image-dialog-title"
           data-tanka-image-target="dialog"
           data-action="click->tanka-image#closeOnBackdrop">

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -75,6 +75,20 @@
 
               <div class="tanka-image__controls">
                 <div>
+                  <label for="tanka-image-preset">おすすめ背景</label>
+                  <select id="tanka-image-preset"
+                          class="form-control"
+                          data-tanka-image-target="preset"
+                          data-action="change->tanka-image#selectPreset">
+                    <option value="white">白地</option>
+                    <option value="washi">和紙</option>
+                    <option value="sora">空</option>
+                    <option value="wakakusa">若草</option>
+                    <option value="sumi">墨</option>
+                  </select>
+                </div>
+
+                <div>
                   <label for="tanka-image-background-color">背景色</label>
                   <input id="tanka-image-background-color"
                          type="color"

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -40,3 +40,68 @@
   </div>
   <p class="lg"><%= @post.tanka.html_safe %></p>
 </div>
+
+<div class="tanka-image horizontal serif mx-auto mt-4 mb-6"
+     data-controller="tanka-image"
+     data-tanka-image-tanka-value="<%= @post.tanka_text %>"
+     data-tanka-image-author-name-value="<%= @user.name %>"
+     data-tanka-image-site-name-value="Utakata">
+  <h4>短歌画像</h4>
+  <div class="tanka-image__layout">
+    <canvas class="tanka-image__canvas"
+            width="1200"
+            height="1600"
+            data-tanka-image-target="canvas"
+            aria-label="短歌画像のプレビュー"></canvas>
+
+    <div class="tanka-image__controls">
+      <div>
+        <label for="tanka-image-template">背景</label>
+        <select id="tanka-image-template"
+                class="form-control"
+                data-tanka-image-target="template"
+                data-action="change->tanka-image#selectTemplate">
+          <option value="washi">和紙</option>
+          <option value="sora">空色</option>
+          <option value="sumi">墨色</option>
+        </select>
+      </div>
+
+      <div>
+        <label for="tanka-image-text-color">文字色</label>
+        <input id="tanka-image-text-color"
+               type="color"
+               class="form-control form-control-color"
+               value="#20242a"
+               data-tanka-image-target="textColor"
+               data-action="input->tanka-image#render">
+      </div>
+
+      <div class="form-check">
+        <input id="tanka-image-author"
+               type="checkbox"
+               class="form-check-input"
+               checked
+               data-tanka-image-target="author"
+               data-action="change->tanka-image#render">
+        <label class="form-check-label" for="tanka-image-author">作者名を表示</label>
+      </div>
+
+      <div class="form-check">
+        <input id="tanka-image-site"
+               type="checkbox"
+               class="form-check-input"
+               checked
+               data-tanka-image-target="site"
+               data-action="change->tanka-image#render">
+        <label class="form-check-label" for="tanka-image-site">サイト名を表示</label>
+      </div>
+
+      <button type="button"
+              class="btn btn-primary"
+              data-action="tanka-image#download">
+        PNGをダウンロード
+      </button>
+    </div>
+  </div>
+</div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -57,7 +57,8 @@
        id="tanka-image-modal"
        tabindex="-1"
        aria-labelledby="tanka-image-modal-title"
-       aria-hidden="true">
+       aria-hidden="true"
+       data-action="hide.bs.modal->tanka-image#releaseModalFocus">
     <div class="modal-dialog modal-lg modal-dialog-centered modal-dialog-scrollable">
       <div class="modal-content">
         <div class="modal-header">

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -81,10 +81,10 @@
                           data-tanka-image-target="preset"
                           data-action="change->tanka-image#selectPreset">
                     <option value="white">白地</option>
+                    <option value="sumi">墨</option>
                     <option value="washi">和紙</option>
                     <option value="sora">空</option>
                     <option value="wakakusa">若草</option>
-                    <option value="sumi">墨</option>
                   </select>
                 </div>
 

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -123,7 +123,7 @@
                 <button type="button"
                         class="tanka-image__control--download btn btn-primary"
                         data-action="tanka-image#download">
-                  画像をダウンロード
+                  画像を保存する
                 </button>
               </div>
             </div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,96 +1,117 @@
 <% @title = "#{@tanka}／#{@user.name}" %>
 <% @description = "#{@user.name}の短歌：#{@tanka}" %>
 
-<div class="mt-4 vertical serif mx-auto text-nowrap">
-  <div class="vertical-flex">
-    <div>
-      <%= link_to avatar_image_tag(@user, :medium, class: 'rounded align-baseline'), user_path(@user) %>
-    </div>
-    <div>
-      <%= link_to @user.name, user_path(@user), class: 'lg tanka-link' %>
-    </div>
-    <div>
-      <%= @post.published_at.strftime('%Y.%-m.%-d %-H:%M') %>
-    </div>
-    <div class="my-1">
-      <a href="<%= @twitter_share_url %>" target="_blank" rel="noopener noreferrer">
-        <i class="lg bi bi-twitter bi-vertical"></i>
-      </a>
-    </div>
-    <% if current_user && current_user.id != @post.user_id %>
-      <% if current_user.following?(@post) %>
-        <%= render 'favorites/unlike', post: @post, size: 'lg' %>
-      <% else %>
-        <%= render 'favorites/like', post: @post, size: 'lg' %>
-      <% end %>
-    <% else %>
-      <div>
-        <i class="lg bi bi-suit-heart-fill bi-vertical"></i>
-      </div>
-    <% end %>
-    <%= render 'favorites/favorites_count', post: @post, size: 'lg' %>
-    <% if current_user && current_user.id == @user.id %>
-      <div class="my-1">
-        <%= link_to content_tag(:i, '', class: "lg bi bi-pencil bi-vertical"), edit_post_path(@post) %>
-      </div>
-      <div class="my-1">
-        <%= link_to content_tag(:i, '', class: "lg bi bi-trash bi-vertical"), post_path(@post), data: { turbo_method: :delete, turbo_confirm: '本当に削除しますか？' } %>
-      </div>
-    <% end %>
-  </div>
-  <p class="lg"><%= @post.tanka.html_safe %></p>
-</div>
-
-<div class="tanka-image horizontal serif mx-auto mt-4 mb-6"
-     data-controller="tanka-image"
+<div data-controller="tanka-image"
      data-tanka-image-tanka-value="<%= @post.tanka_text %>"
      data-tanka-image-author-name-value="<%= @user.name %>">
-  <h4>短歌画像</h4>
-  <div class="tanka-image__layout">
-    <canvas class="tanka-image__canvas"
-            width="1200"
-            height="1600"
-            data-tanka-image-target="canvas"
-            aria-label="短歌画像のプレビュー"></canvas>
-
-    <div class="tanka-image__controls">
+  <div class="mt-4 vertical serif mx-auto text-nowrap">
+    <div class="vertical-flex">
       <div>
-        <label for="tanka-image-template">背景</label>
-        <select id="tanka-image-template"
-                class="form-control"
-                data-tanka-image-target="template"
-                data-action="change->tanka-image#selectTemplate">
-          <option value="washi">和紙</option>
-          <option value="sora">空色</option>
-          <option value="sumi">墨色</option>
-        </select>
+        <%= link_to avatar_image_tag(@user, :medium, class: 'rounded align-baseline'), user_path(@user) %>
       </div>
-
       <div>
-        <label for="tanka-image-text-color">文字色</label>
-        <input id="tanka-image-text-color"
-               type="color"
-               class="form-control form-control-color"
-               value="#20242a"
-               data-tanka-image-target="textColor"
-               data-action="input->tanka-image#render">
+        <%= link_to @user.name, user_path(@user), class: 'lg tanka-link' %>
       </div>
-
-      <div class="form-check">
-        <input id="tanka-image-author"
-               type="checkbox"
-               class="form-check-input"
-               checked
-               data-tanka-image-target="author"
-               data-action="change->tanka-image#render">
-        <label class="form-check-label" for="tanka-image-author">作者名を表示</label>
+      <div>
+        <%= @post.published_at.strftime('%Y.%-m.%-d %-H:%M') %>
       </div>
-
-      <button type="button"
-              class="btn btn-primary"
-              data-action="tanka-image#download">
-        PNGをダウンロード
-      </button>
+      <div class="my-1">
+        <a href="<%= @twitter_share_url %>" target="_blank" rel="noopener noreferrer">
+          <i class="lg bi bi-twitter bi-vertical"></i>
+        </a>
+      </div>
+      <div class="my-1">
+        <button type="button"
+                class="tanka-image-trigger"
+                data-action="tanka-image#open"
+                aria-label="短歌画像を生成">
+          <i class="lg bi bi-card-image bi-vertical"></i>
+        </button>
+      </div>
+      <% if current_user && current_user.id != @post.user_id %>
+        <% if current_user.following?(@post) %>
+          <%= render 'favorites/unlike', post: @post, size: 'lg' %>
+        <% else %>
+          <%= render 'favorites/like', post: @post, size: 'lg' %>
+        <% end %>
+      <% else %>
+        <div>
+          <i class="lg bi bi-suit-heart-fill bi-vertical"></i>
+        </div>
+      <% end %>
+      <%= render 'favorites/favorites_count', post: @post, size: 'lg' %>
+      <% if current_user && current_user.id == @user.id %>
+        <div class="my-1">
+          <%= link_to content_tag(:i, '', class: "lg bi bi-pencil bi-vertical"), edit_post_path(@post) %>
+        </div>
+        <div class="my-1">
+          <%= link_to content_tag(:i, '', class: "lg bi bi-trash bi-vertical"), post_path(@post), data: { turbo_method: :delete, turbo_confirm: '本当に削除しますか？' } %>
+        </div>
+      <% end %>
     </div>
+    <p class="lg"><%= @post.tanka.html_safe %></p>
   </div>
+
+  <dialog class="tanka-image-dialog horizontal serif"
+          aria-labelledby="tanka-image-dialog-title"
+          data-tanka-image-target="dialog"
+          data-action="click->tanka-image#closeOnBackdrop">
+    <div>
+      <div class="tanka-image-dialog__header">
+        <h5 id="tanka-image-dialog-title">短歌画像</h5>
+        <button type="button" class="btn-close" data-action="tanka-image#close" aria-label="閉じる"></button>
+      </div>
+      <div class="tanka-image-dialog__body">
+        <div class="tanka-image">
+          <div class="tanka-image__layout">
+            <canvas class="tanka-image__canvas"
+                    width="1200"
+                    height="1600"
+                    data-tanka-image-target="canvas"
+                    aria-label="短歌画像のプレビュー"></canvas>
+
+            <div class="tanka-image__controls">
+              <div>
+                <label for="tanka-image-template">背景</label>
+                <select id="tanka-image-template"
+                        class="form-control"
+                        data-tanka-image-target="template"
+                        data-action="change->tanka-image#selectTemplate">
+                  <option value="washi">和紙</option>
+                  <option value="sora">空色</option>
+                  <option value="sumi">墨色</option>
+                </select>
+              </div>
+
+              <div>
+                <label for="tanka-image-text-color">文字色</label>
+                <input id="tanka-image-text-color"
+                       type="color"
+                       class="form-control form-control-color"
+                       value="#20242a"
+                       data-tanka-image-target="textColor"
+                       data-action="input->tanka-image#render">
+              </div>
+
+              <div class="form-check">
+                <input id="tanka-image-author"
+                       type="checkbox"
+                       class="form-check-input"
+                       checked
+                       data-tanka-image-target="author"
+                       data-action="change->tanka-image#render">
+                <label class="form-check-label" for="tanka-image-author">作者名を表示</label>
+              </div>
+
+              <button type="button"
+                      class="btn btn-primary"
+                      data-action="tanka-image#download">
+                PNGをダウンロード
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </dialog>
 </div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -25,7 +25,7 @@
                 class="tanka-image-trigger"
                 data-bs-toggle="modal"
                 data-bs-target="#tanka-image-modal"
-                aria-label="短歌画像を生成">
+                aria-label="短歌画像">
           <i class="lg bi bi-card-image bi-vertical"></i>
         </button>
       </div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -75,24 +75,27 @@
 
               <div class="tanka-image__controls">
                 <div class="tanka-image__control-group">
-                  <div class="tanka-image__control-group-title">背景</div>
-                  <div class="tanka-image__control-row">
-                    <div class="tanka-image__control tanka-image__control--preset">
-                      <label for="tanka-image-preset">おすすめ</label>
-                      <select id="tanka-image-preset"
-                              class="form-control"
-                              data-tanka-image-target="preset"
-                              data-action="change->tanka-image#selectPreset">
-                        <option value="white">白地</option>
-                        <option value="washi">和紙</option>
-                        <option value="sora">空</option>
-                        <option value="wakakusa">若草</option>
-                        <option value="sumi">墨</option>
-                      </select>
-                    </div>
+                  <div class="tanka-image__control-group-title">配色</div>
+                  <div class="tanka-image__control tanka-image__control--preset">
+                    <label for="tanka-image-preset">プリセット</label>
+                    <select id="tanka-image-preset"
+                            class="form-control"
+                            data-tanka-image-target="preset"
+                            data-action="change->tanka-image#selectPreset">
+                      <option value="white">白地</option>
+                      <option value="washi">和紙</option>
+                      <option value="sora">空</option>
+                      <option value="wakakusa">若草</option>
+                      <option value="sumi">墨</option>
+                    </select>
+                  </div>
+                </div>
 
+                <div class="tanka-image__control-group">
+                  <div class="tanka-image__control-group-title">微調整</div>
+                  <div class="tanka-image__control-row tanka-image__control-row--colors">
                     <div class="tanka-image__control tanka-image__control--color">
-                      <label for="tanka-image-background-color">色</label>
+                      <label for="tanka-image-background-color">背景色</label>
                       <input id="tanka-image-background-color"
                              type="color"
                              class="form-control form-control-color"
@@ -100,14 +103,9 @@
                              data-tanka-image-target="backgroundColor"
                              data-action="input->tanka-image#render">
                     </div>
-                  </div>
-                </div>
 
-                <div class="tanka-image__control-group">
-                  <div class="tanka-image__control-group-title">文字</div>
-                  <div class="tanka-image__control-row">
                     <div class="tanka-image__control tanka-image__control--color">
-                      <label for="tanka-image-text-color">色</label>
+                      <label for="tanka-image-text-color">文字色</label>
                       <input id="tanka-image-text-color"
                              type="color"
                              class="form-control form-control-color"
@@ -115,16 +113,16 @@
                              data-tanka-image-target="textColor"
                              data-action="input->tanka-image#render">
                     </div>
+                  </div>
 
-                    <div class="tanka-image__control tanka-image__control--author form-check">
-                      <input id="tanka-image-author"
-                             type="checkbox"
-                             class="form-check-input"
-                             checked
-                             data-tanka-image-target="author"
-                             data-action="change->tanka-image#render">
-                      <label class="form-check-label" for="tanka-image-author">作者名を表示</label>
-                    </div>
+                  <div class="tanka-image__control tanka-image__control--author form-check">
+                    <input id="tanka-image-author"
+                           type="checkbox"
+                           class="form-check-input"
+                           checked
+                           data-tanka-image-target="author"
+                           data-action="change->tanka-image#render">
+                    <label class="form-check-label" for="tanka-image-author">作者名を表示</label>
                   </div>
                 </div>
 

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -23,7 +23,8 @@
       <div class="my-1">
         <button type="button"
                 class="tanka-image-trigger"
-                data-action="tanka-image#open"
+                data-bs-toggle="modal"
+                data-bs-target="#tanka-image-modal"
                 aria-label="短歌画像を生成">
           <i class="lg bi bi-card-image bi-vertical"></i>
         </button>
@@ -52,68 +53,71 @@
     <p class="lg"><%= @post.tanka.html_safe %></p>
   </div>
 
-  <dialog class="tanka-image-dialog horizontal"
-          aria-labelledby="tanka-image-dialog-title"
-          data-tanka-image-target="dialog"
-          data-action="click->tanka-image#closeOnBackdrop">
-    <div>
-      <div class="tanka-image-dialog__header">
-        <h5 id="tanka-image-dialog-title">短歌画像</h5>
-        <button type="button" class="btn-close" data-action="tanka-image#close" aria-label="閉じる"></button>
-      </div>
-      <div class="tanka-image-dialog__body">
-        <div class="tanka-image">
-          <div class="tanka-image__layout">
-            <canvas class="tanka-image__canvas"
-                    width="1200"
-                    height="1600"
-                    data-tanka-image-target="canvas"
-                    aria-label="短歌画像のプレビュー"></canvas>
+  <div class="modal fade horizontal"
+       id="tanka-image-modal"
+       tabindex="-1"
+       aria-labelledby="tanka-image-modal-title"
+       aria-hidden="true">
+    <div class="modal-dialog modal-lg modal-dialog-centered modal-dialog-scrollable">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title" id="tanka-image-modal-title">短歌画像</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="閉じる"></button>
+        </div>
+        <div class="modal-body">
+          <div class="tanka-image">
+            <div class="tanka-image__layout">
+              <canvas class="tanka-image__canvas"
+                      width="1200"
+                      height="1600"
+                      data-tanka-image-target="canvas"
+                      aria-label="短歌画像のプレビュー"></canvas>
 
-            <div class="tanka-image__controls">
-              <div>
-                <label for="tanka-image-template">背景</label>
-                <select id="tanka-image-template"
-                        class="form-control"
-                        data-tanka-image-target="template"
-                        data-action="change->tanka-image#selectTemplate">
-                  <option value="white">白地</option>
-                  <option value="washi">和紙</option>
-                  <option value="sora">空</option>
-                  <option value="wakakusa">若草</option>
-                  <option value="sumi">墨</option>
-                </select>
+              <div class="tanka-image__controls">
+                <div>
+                  <label for="tanka-image-template">背景</label>
+                  <select id="tanka-image-template"
+                          class="form-control"
+                          data-tanka-image-target="template"
+                          data-action="change->tanka-image#selectTemplate">
+                    <option value="white">白地</option>
+                    <option value="washi">和紙</option>
+                    <option value="sora">空</option>
+                    <option value="wakakusa">若草</option>
+                    <option value="sumi">墨</option>
+                  </select>
+                </div>
+
+                <div>
+                  <label for="tanka-image-text-color">文字色</label>
+                  <input id="tanka-image-text-color"
+                         type="color"
+                         class="form-control form-control-color"
+                         value="#20242a"
+                         data-tanka-image-target="textColor"
+                         data-action="input->tanka-image#render">
+                </div>
+
+                <div class="form-check">
+                  <input id="tanka-image-author"
+                         type="checkbox"
+                         class="form-check-input"
+                         checked
+                         data-tanka-image-target="author"
+                         data-action="change->tanka-image#render">
+                  <label class="form-check-label" for="tanka-image-author">作者名を表示</label>
+                </div>
+
+                <button type="button"
+                        class="btn btn-primary"
+                        data-action="tanka-image#download">
+                  画像をダウンロード
+                </button>
               </div>
-
-              <div>
-                <label for="tanka-image-text-color">文字色</label>
-                <input id="tanka-image-text-color"
-                       type="color"
-                       class="form-control form-control-color"
-                       value="#20242a"
-                       data-tanka-image-target="textColor"
-                       data-action="input->tanka-image#render">
-              </div>
-
-              <div class="form-check">
-                <input id="tanka-image-author"
-                       type="checkbox"
-                       class="form-check-input"
-                       checked
-                       data-tanka-image-target="author"
-                       data-action="change->tanka-image#render">
-                <label class="form-check-label" for="tanka-image-author">作者名を表示</label>
-              </div>
-
-              <button type="button"
-                      class="btn btn-primary"
-                      data-action="tanka-image#download">
-                画像をダウンロード
-              </button>
             </div>
           </div>
         </div>
       </div>
     </div>
-  </dialog>
+  </div>
 </div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -75,17 +75,13 @@
 
               <div class="tanka-image__controls">
                 <div>
-                  <label for="tanka-image-template">背景</label>
-                  <select id="tanka-image-template"
-                          class="form-control"
-                          data-tanka-image-target="template"
-                          data-action="change->tanka-image#selectTemplate">
-                    <option value="white">白地</option>
-                    <option value="washi">和紙</option>
-                    <option value="sora">空</option>
-                    <option value="wakakusa">若草</option>
-                    <option value="sumi">墨</option>
-                  </select>
+                  <label for="tanka-image-background-color">背景色</label>
+                  <input id="tanka-image-background-color"
+                         type="color"
+                         class="form-control form-control-color"
+                         value="#ffffff"
+                         data-tanka-image-target="backgroundColor"
+                         data-action="input->tanka-image#render">
                 </div>
 
                 <div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -44,8 +44,7 @@
 <div class="tanka-image horizontal serif mx-auto mt-4 mb-6"
      data-controller="tanka-image"
      data-tanka-image-tanka-value="<%= @post.tanka_text %>"
-     data-tanka-image-author-name-value="<%= @user.name %>"
-     data-tanka-image-site-name-value="Utakata">
+     data-tanka-image-author-name-value="<%= @user.name %>">
   <h4>短歌画像</h4>
   <div class="tanka-image__layout">
     <canvas class="tanka-image__canvas"
@@ -85,16 +84,6 @@
                data-tanka-image-target="author"
                data-action="change->tanka-image#render">
         <label class="form-check-label" for="tanka-image-author">作者名を表示</label>
-      </div>
-
-      <div class="form-check">
-        <input id="tanka-image-site"
-               type="checkbox"
-               class="form-check-input"
-               checked
-               data-tanka-image-target="site"
-               data-action="change->tanka-image#render">
-        <label class="form-check-label" for="tanka-image-site">サイト名を表示</label>
       </div>
 
       <button type="button"

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -74,56 +74,50 @@
                       aria-label="短歌画像のプレビュー"></canvas>
 
               <div class="tanka-image__controls">
-                <div class="tanka-image__control-group">
-                  <div class="tanka-image__control-group-title">配色</div>
-                  <div class="tanka-image__control tanka-image__control--preset">
-                    <label for="tanka-image-preset">プリセット</label>
-                    <select id="tanka-image-preset"
-                            class="form-control"
-                            data-tanka-image-target="preset"
-                            data-action="change->tanka-image#selectPreset">
-                      <option value="white">白地</option>
-                      <option value="washi">和紙</option>
-                      <option value="sora">空</option>
-                      <option value="wakakusa">若草</option>
-                      <option value="sumi">墨</option>
-                    </select>
+                <div class="tanka-image__control tanka-image__control--preset">
+                  <label for="tanka-image-preset">雰囲気</label>
+                  <select id="tanka-image-preset"
+                          class="form-control"
+                          data-tanka-image-target="preset"
+                          data-action="change->tanka-image#selectPreset">
+                    <option value="white">白地</option>
+                    <option value="washi">和紙</option>
+                    <option value="sora">空</option>
+                    <option value="wakakusa">若草</option>
+                    <option value="sumi">墨</option>
+                  </select>
+                </div>
+
+                <div class="tanka-image__control-row tanka-image__control-row--colors">
+                  <div class="tanka-image__control tanka-image__control--color">
+                    <label for="tanka-image-background-color">背景色</label>
+                    <input id="tanka-image-background-color"
+                           type="color"
+                           class="form-control form-control-color"
+                           value="#ffffff"
+                           data-tanka-image-target="backgroundColor"
+                           data-action="input->tanka-image#render">
+                  </div>
+
+                  <div class="tanka-image__control tanka-image__control--color">
+                    <label for="tanka-image-text-color">文字色</label>
+                    <input id="tanka-image-text-color"
+                           type="color"
+                           class="form-control form-control-color"
+                           value="#20242a"
+                           data-tanka-image-target="textColor"
+                           data-action="input->tanka-image#render">
                   </div>
                 </div>
 
-                <div class="tanka-image__control-group">
-                  <div class="tanka-image__control-group-title">微調整</div>
-                  <div class="tanka-image__control-row tanka-image__control-row--colors">
-                    <div class="tanka-image__control tanka-image__control--color">
-                      <label for="tanka-image-background-color">背景色</label>
-                      <input id="tanka-image-background-color"
-                             type="color"
-                             class="form-control form-control-color"
-                             value="#ffffff"
-                             data-tanka-image-target="backgroundColor"
-                             data-action="input->tanka-image#render">
-                    </div>
-
-                    <div class="tanka-image__control tanka-image__control--color">
-                      <label for="tanka-image-text-color">文字色</label>
-                      <input id="tanka-image-text-color"
-                             type="color"
-                             class="form-control form-control-color"
-                             value="#20242a"
-                             data-tanka-image-target="textColor"
-                             data-action="input->tanka-image#render">
-                    </div>
-                  </div>
-
-                  <div class="tanka-image__control tanka-image__control--author form-check">
-                    <input id="tanka-image-author"
-                           type="checkbox"
-                           class="form-check-input"
-                           checked
-                           data-tanka-image-target="author"
-                           data-action="change->tanka-image#render">
-                    <label class="form-check-label" for="tanka-image-author">作者名を表示</label>
-                  </div>
+                <div class="tanka-image__control tanka-image__control--author form-check">
+                  <input id="tanka-image-author"
+                         type="checkbox"
+                         class="form-check-input"
+                         checked
+                         data-tanka-image-target="author"
+                         data-action="change->tanka-image#render">
+                  <label class="form-check-label" for="tanka-image-author">作者名を表示</label>
                 </div>
 
                 <button type="button"

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -75,7 +75,7 @@
 
               <div class="tanka-image__controls">
                 <div class="tanka-image__control tanka-image__control--preset">
-                  <label for="tanka-image-preset">雰囲気</label>
+                  <label for="tanka-image-preset">おすすめ</label>
                   <select id="tanka-image-preset"
                           class="form-control"
                           data-tanka-image-target="preset"


### PR DESCRIPTION
## 変更内容

- 投稿詳細画面に短歌画像生成パネルを追加
- Canvasで縦書き短歌画像のプレビューを描画
- 背景テンプレート、文字色、作者名、サイト名の表示設定を追加
- PNGダウンロードボタンを追加

## 確認内容

- npm run lint
- npm run build
- docker compose run --rm app bin/rubocop
- ブラウザで投稿詳細画面のプレビュー表示、背景変更、作者名表示切替、PNGボタン押下を確認

Resolves #1065