### PR TITLE
Dart SassのDeprecation Warningをオフにする

### DIFF
--- a/config/webpack/webpack.config.js
+++ b/config/webpack/webpack.config.js
@@ -24,7 +24,19 @@ module.exports = {
       },
       {
         test: /\.s?[ac]ss$/i,
-        use: [MiniCssExtractPlugin.loader, 'css-loader', 'sass-loader'],
+        use: [
+          MiniCssExtractPlugin.loader,
+          'css-loader',
+          {
+            loader: 'sass-loader',
+            options: {
+              sassOptions: {
+                quietDeps: true,
+                silenceDeprecations: ['import'],
+              },
+            },
+          },
+        ],
       },
     ],
   },


### PR DESCRIPTION
## 変更内容

- `sass-loader` に `sassOptions` を追加しました。
- Bootstrap など依存パッケージ由来の Sass deprecation warning を `quietDeps` で抑制しました。
- `@import` の deprecation warning を `silenceDeprecations` で抑制しました。

## 目的

Bootstrap 側で Dart Sass 3.0.0 対応が完了するまで、ビルド時に大量に出力される deprecation warning を非表示にするためです。

## 動作確認

- `npm run build`
- `npm run lint`

Resolves #1067