### PR TITLE
短歌画像の保存方法をモバイル向けに最適化する

### DIFF
--- a/app/assets/javascripts/controllers/tanka_image_controller.js
+++ b/app/assets/javascripts/controllers/tanka_image_controller.js
@@ -58,13 +58,51 @@ export default class extends Controller {
     this.drawMeta(context, tankaMetrics);
   }
 
-  download() {
+  async download() {
     this.render();
 
+    const blob = await this.createImageBlob();
+    const file = new File([blob], 'utakata-tanka.png', { type: blob.type });
+    const shareData = {
+      files: [file],
+      title: '短歌画像',
+    };
+
+    if (navigator.canShare?.(shareData)) {
+      try {
+        await navigator.share(shareData);
+        return;
+      } catch (error) {
+        if (error.name === 'AbortError') {
+          return;
+        }
+      }
+    }
+
+    this.downloadBlob(blob);
+  }
+
+  createImageBlob() {
+    return new Promise((resolve, reject) => {
+      this.canvasTarget.toBlob((blob) => {
+        if (!blob) {
+          reject(new Error('短歌画像の生成に失敗しました'));
+          return;
+        }
+
+        resolve(blob);
+      }, 'image/png');
+    });
+  }
+
+  downloadBlob(blob) {
     const link = document.createElement('a');
+    const objectUrl = URL.createObjectURL(blob);
+
     link.download = 'utakata-tanka.png';
-    link.href = this.canvasTarget.toDataURL('image/png');
+    link.href = objectUrl;
     link.click();
+    setTimeout(() => URL.revokeObjectURL(objectUrl), 0);
   }
 
   releaseModalFocus(event) {

--- a/app/assets/javascripts/controllers/tanka_image_controller.js
+++ b/app/assets/javascripts/controllers/tanka_image_controller.js
@@ -87,11 +87,7 @@ export default class extends Controller {
       return false;
     }
 
-    if (navigator.userAgentData?.mobile) {
-      return true;
-    }
-
-    return /Android|iPhone|iPad|iPod/i.test(navigator.userAgent);
+    return window.matchMedia('(hover: none) and (pointer: coarse)').matches;
   }
 
   createImageBlob() {

--- a/app/assets/javascripts/controllers/tanka_image_controller.js
+++ b/app/assets/javascripts/controllers/tanka_image_controller.js
@@ -68,7 +68,7 @@ export default class extends Controller {
       title: '短歌画像',
     };
 
-    if (navigator.canShare?.(shareData)) {
+    if (this.shouldUseNativeShare(shareData)) {
       try {
         await navigator.share(shareData);
         return;
@@ -80,6 +80,18 @@ export default class extends Controller {
     }
 
     this.downloadBlob(blob);
+  }
+
+  shouldUseNativeShare(shareData) {
+    if (!navigator.canShare?.(shareData)) {
+      return false;
+    }
+
+    if (navigator.userAgentData?.mobile) {
+      return true;
+    }
+
+    return /Android|iPhone|iPad|iPod/i.test(navigator.userAgent);
   }
 
   createImageBlob() {

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -124,7 +124,7 @@
                 <button type="button"
                         class="tanka-image__control--download btn btn-primary"
                         data-action="tanka-image#download">
-                  画像を保存・共有する
+                  画像を保存する
                 </button>
               </div>
             </div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -124,7 +124,7 @@
                 <button type="button"
                         class="tanka-image__control--download btn btn-primary"
                         data-action="tanka-image#download">
-                  画像を保存する
+                  画像を保存・共有する
                 </button>
               </div>
             </div>


### PR DESCRIPTION
## 変更内容

- 短歌画像の保存処理でCanvasをPNG Blob/Fileに変換するようにしました
- ファイル共有に対応している環境ではWeb Share APIを使ってOS標準の共有シートを開くようにしました
- Web Share APIで共有できない環境では従来どおりPNGファイルとしてダウンロードするようにしました
- ボタン文言を実際の挙動に合わせて「画像を保存・共有する」に変更しました

## 目的

iPhoneなどのモバイル端末で、短歌画像を写真アプリなどへ保存しやすい導線にするためです。

## 確認

- `npm run lint`
- `npm run build`

Resolves #1071