### PR TITLE
短歌画像のタイトルを短歌本文にする

### DIFF
--- a/app/assets/javascripts/controllers/tanka_image_controller.js
+++ b/app/assets/javascripts/controllers/tanka_image_controller.js
@@ -57,7 +57,7 @@ export default class extends Controller {
     this.render();
 
     const blob = await this.createImageBlob();
-    const file = new File([blob], this.imageFileName(), { type: blob.type });
+    const file = new File([blob], `${this.tankaTextValue}.png`, { type: blob.type });
     const shareData = {
       files: [file],
       title: this.tankaTextValue,
@@ -96,16 +96,6 @@ export default class extends Controller {
         resolve(blob);
       }, 'image/png');
     });
-  }
-
-  imageFileName() {
-    const fallbackFileName = 'utakata-tanka';
-    const fileName = this.tankaTextValue
-      .replace(/[\\/:*?"<>|]/g, '')
-      .replace(/\s+/g, ' ')
-      .trim();
-
-    return `${fileName || fallbackFileName}.png`;
   }
 
   downloadBlob(blob, fileName) {

--- a/app/assets/javascripts/controllers/tanka_image_controller.js
+++ b/app/assets/javascripts/controllers/tanka_image_controller.js
@@ -24,13 +24,7 @@ const PRESETS = {
 };
 
 export default class extends Controller {
-  static targets = [
-    'backgroundColor',
-    'canvas',
-    'preset',
-    'textColor',
-    'author',
-  ];
+  static targets = ['backgroundColor', 'canvas', 'preset', 'textColor', 'author'];
 
   static values = {
     authorName: String,
@@ -144,9 +138,7 @@ export default class extends Controller {
     const fontSize = this.calculateFontSize(context, units, verticalMargin, lineHeightRatio);
     const lineHeight = fontSize * lineHeightRatio;
     const maxRows =
-      Math.floor(
-        (context.canvas.height - verticalMargin * 2 - fontSize) / lineHeight,
-      ) + 1;
+      Math.floor((context.canvas.height - verticalMargin * 2 - fontSize) / lineHeight) + 1;
     const columnGap = 88;
     const positions = [];
     let column = 0;
@@ -177,14 +169,11 @@ export default class extends Controller {
       return null;
     }
 
-    const totalColumns =
-      Math.max(...positions.map((position) => position.column)) + 1;
-    const totalRows =
-      Math.max(...positions.map((position) => position.row + position.rowSpan));
+    const totalColumns = Math.max(...positions.map((position) => position.column)) + 1;
+    const totalRows = Math.max(...positions.map((position) => position.row + position.rowSpan));
     const textHeight = (totalRows - 1) * lineHeight + fontSize;
     const firstRowY = (context.canvas.height - textHeight) / 2 + fontSize / 2;
-    const firstColumnX =
-      context.canvas.width / 2 + ((totalColumns - 1) * columnGap) / 2;
+    const firstColumnX = context.canvas.width / 2 + ((totalColumns - 1) * columnGap) / 2;
     const bottomY = firstRowY + (totalRows - 1) * lineHeight + fontSize / 2;
 
     positions.forEach((position) => {
@@ -202,17 +191,10 @@ export default class extends Controller {
     const minFontSize = 38;
     const maxFontSize = 58;
     const availableHeight = context.canvas.height - verticalMargin * 2;
-    const rowCount = Math.min(
-      this.maxRowsWithoutWrapping(units),
-      maxRowsForSingleColumn,
-    );
-    const fittedFontSize =
-      availableHeight / (1 + (rowCount - 1) * lineHeightRatio);
+    const rowCount = Math.min(this.maxRowsWithoutWrapping(units), maxRowsForSingleColumn);
+    const fittedFontSize = availableHeight / (1 + (rowCount - 1) * lineHeightRatio);
 
-    return Math.max(
-      minFontSize,
-      Math.min(Math.floor(fittedFontSize), maxFontSize),
-    );
+    return Math.max(minFontSize, Math.min(Math.floor(fittedFontSize), maxFontSize));
   }
 
   maxRowsWithoutWrapping(units) {
@@ -316,8 +298,7 @@ export default class extends Controller {
       baseCharacters.length > 1
         ? baseHeight / Math.max(rubyCharacters.length - 1, 1)
         : rubyFontSize * 0.9;
-    const rubyY =
-      y + baseHeight / 2 - ((rubyCharacters.length - 1) * rubyLineHeight) / 2;
+    const rubyY = y + baseHeight / 2 - ((rubyCharacters.length - 1) * rubyLineHeight) / 2;
 
     rubyCharacters.forEach((character, index) => {
       context.font = `${rubyFontSize}px serif`;

--- a/app/assets/javascripts/controllers/tanka_image_controller.js
+++ b/app/assets/javascripts/controllers/tanka_image_controller.js
@@ -35,6 +35,7 @@ export default class extends Controller {
   static values = {
     authorName: String,
     tanka: String,
+    tankaText: String,
   };
 
   connect() {
@@ -62,10 +63,10 @@ export default class extends Controller {
     this.render();
 
     const blob = await this.createImageBlob();
-    const file = new File([blob], 'utakata-tanka.png', { type: blob.type });
+    const file = new File([blob], this.imageFileName(), { type: blob.type });
     const shareData = {
       files: [file],
-      title: '短歌画像',
+      title: this.tankaTextValue,
     };
 
     if (this.shouldUseNativeShare(shareData)) {
@@ -79,7 +80,7 @@ export default class extends Controller {
       }
     }
 
-    this.downloadBlob(blob);
+    this.downloadBlob(blob, file.name);
   }
 
   shouldUseNativeShare(shareData) {
@@ -103,11 +104,21 @@ export default class extends Controller {
     });
   }
 
-  downloadBlob(blob) {
+  imageFileName() {
+    const fallbackFileName = 'utakata-tanka';
+    const fileName = this.tankaTextValue
+      .replace(/[\\/:*?"<>|]/g, '')
+      .replace(/\s+/g, ' ')
+      .trim();
+
+    return `${fileName || fallbackFileName}.png`;
+  }
+
+  downloadBlob(blob, fileName) {
     const link = document.createElement('a');
     const objectUrl = URL.createObjectURL(blob);
 
-    link.download = 'utakata-tanka.png';
+    link.download = fileName;
     link.href = objectUrl;
     link.click();
     setTimeout(() => URL.revokeObjectURL(objectUrl), 0);

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -3,6 +3,7 @@
 
 <div data-controller="tanka-image"
      data-tanka-image-tanka-value="<%= @post.tanka %>"
+     data-tanka-image-tanka-text-value="<%= @post.tanka_text %>"
      data-tanka-image-author-name-value="<%= @user.name %>">
   <div class="mt-4 vertical serif mx-auto text-nowrap">
     <div class="vertical-flex">


### PR DESCRIPTION
## 変更内容

- 短歌画像の保存ファイル名に `Post#tanka_text` の文字列を使うようにしました
- Web Share API に渡す共有タイトルにも短歌本文を設定するようにしました
- ファイル名として扱いづらい文字は除去し、空文字になった場合のみ従来の `utakata-tanka` を使うようにしました

## 確認したこと

- `npm run lint`
- `npm run build`
- `docker compose run --rm app bin/rubocop`

Resolves #1073