### PR TITLE
短歌画像のシェア情報に短歌詳細画面のURLを追加する

### DIFF
--- a/app/assets/javascripts/controllers/tanka_image_controller.js
+++ b/app/assets/javascripts/controllers/tanka_image_controller.js
@@ -30,6 +30,7 @@ export default class extends Controller {
     authorName: String,
     tanka: String,
     tankaText: String,
+    url: String,
   };
 
   connect() {
@@ -61,6 +62,7 @@ export default class extends Controller {
     const shareData = {
       files: [file],
       title: this.tankaTextValue,
+      url: this.urlValue,
     };
 
     if (this.shouldUseNativeShare(shareData)) {

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -4,7 +4,8 @@
 <div data-controller="tanka-image"
      data-tanka-image-tanka-value="<%= @post.tanka %>"
      data-tanka-image-tanka-text-value="<%= @post.tanka_text %>"
-     data-tanka-image-author-name-value="<%= @user.name %>">
+     data-tanka-image-author-name-value="<%= @user.name %>"
+     data-tanka-image-url-value="<%= post_url(@post) %>">
   <div class="mt-4 vertical serif mx-auto text-nowrap">
     <div class="vertical-flex">
       <div>


### PR DESCRIPTION
## 概要
- 短歌詳細画面のURLを短歌画像共有用のStimulus controllerへ渡すようにしました
- Web Share APIの共有データに短歌詳細画面のURLを追加しました

## 確認
- npm run lint
- docker compose run --rm app bin/rubocop

Resolves #1075