### PR TITLE
短歌画像モーダルをコンパクトにする

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -276,20 +276,26 @@ label {
   color: $utakata-blue-hover;
 }
 
+.tanka-image-modal__dialog {
+  max-width: 720px;
+}
+
 .tanka-image {
   width: 100%;
 }
 
 .tanka-image__layout {
   display: grid;
-  grid-template-columns: minmax(220px, 360px) minmax(220px, 1fr);
-  gap: 1.5rem;
+  grid-template-columns: minmax(220px, 320px) minmax(220px, 1fr);
+  gap: 1.25rem;
   align-items: start;
 }
 
 .tanka-image__canvas {
   width: 100%;
+  max-width: 320px;
   aspect-ratio: 3 / 4;
+  justify-self: center;
   border: 1px solid #dee2e6;
   background-color: #f8f4ea;
 }
@@ -381,21 +387,38 @@ label {
 }
 
 @media (max-width: 767px) {
+  .tanka-image-modal__dialog {
+    width: min(100% - 1rem, 360px);
+    margin: 0.5rem auto;
+  }
+
+  .tanka-image-modal__dialog .modal-content {
+    max-height: calc(100dvh - 1rem);
+  }
+
+  .tanka-image-modal__dialog .modal-header {
+    padding: 0.75rem 1rem;
+  }
+
   .modal-body {
     padding: 0.75rem;
   }
 
   .tanka-image__layout {
     grid-template-columns: 1fr;
-    gap: 0.75rem;
+    gap: 0.625rem;
+  }
+
+  .tanka-image__canvas {
+    max-width: min(100%, 240px);
   }
 
   .tanka-image__controls {
-    gap: 0.75rem;
+    gap: 0.625rem;
   }
 
   .tanka-image__control-row {
-    gap: 0.75rem;
+    gap: 0.625rem;
     align-items: end;
   }
 
@@ -405,11 +428,13 @@ label {
 
   .tanka-image__control label {
     margin-bottom: 0.25rem;
-    font-size: 0.9rem;
+    font-size: 0.875rem;
   }
 
   .tanka-image__control .form-control {
-    min-height: 38px;
+    min-height: 36px;
+    padding-top: 0.25rem;
+    padding-bottom: 0.25rem;
   }
 
   .tanka-image__control .form-control-color {
@@ -428,5 +453,10 @@ label {
 
   .tanka-image__control--author .form-check-label {
     margin-bottom: 0;
+  }
+
+  .tanka-image__control--download {
+    padding-top: 0.375rem;
+    padding-bottom: 0.375rem;
   }
 }

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -61,7 +61,7 @@
        aria-labelledby="tanka-image-modal-title"
        aria-hidden="true"
        data-action="hide.bs.modal->tanka-image#releaseModalFocus">
-    <div class="modal-dialog modal-lg modal-dialog-centered modal-dialog-scrollable">
+    <div class="modal-dialog modal-dialog-centered modal-dialog-scrollable tanka-image-modal__dialog">
       <div class="modal-content">
         <div class="modal-header">
           <h5 class="modal-title" id="tanka-image-modal-title">短歌画像</h5>


### PR DESCRIPTION
## 概要
- 短歌画像モーダル専用のダイアログ幅を設定し、従来の `modal-lg` よりコンパクトにしました
- モバイル表示時のモーダル余白、ヘッダー余白、キャンバス上限サイズ、入力コントロールの余白を調整しました
- iPhone 17 相当のモバイル幅でも短歌画像プレビューと操作欄が自然に収まるようにしました

## 確認
- npm run build
- npm run lint
- git diff --check

## 未確認
- docker compose run --rm app bin/rubocop（Docker デーモンに接続できず未実行）

Resolves #1077