### PR TITLE
短歌画像のルビの表示の違和感を解消する

### DIFF
--- a/app/assets/javascripts/controllers/tanka_image_controller.js
+++ b/app/assets/javascripts/controllers/tanka_image_controller.js
@@ -274,7 +274,6 @@ export default class extends Controller {
   drawRuby(context, unit, x, y, fontSize, lineHeight) {
     const baseCharacters = Array.from(unit.text);
     const rubyCharacters = Array.from(unit.ruby);
-    const rubyX = x + fontSize * 0.62;
 
     baseCharacters.forEach((character, index) => {
       context.font = `${fontSize}px serif`;
@@ -291,9 +290,10 @@ export default class extends Controller {
     const fittedRubyFontSize =
       baseHeight / (1 + Math.max(rubyCharacters.length - 1, 0) * rubyLineHeightRatio);
     const rubyFontSize = Math.max(
-      Math.min(Math.round(fittedRubyFontSize), Math.round(fontSize * 0.62)),
+      Math.min(Math.round(fittedRubyFontSize), Math.round(fontSize * 0.72)),
       14,
     );
+    const rubyX = x + fontSize / 2 + rubyFontSize / 2 + fontSize * 0.12;
     const rubyLineHeight = rubyFontSize * rubyLineHeightRatio;
     const rubyHeight = (rubyCharacters.length - 1) * rubyLineHeight + rubyFontSize;
     const rubyY = baseCenterY - rubyHeight / 2 + rubyFontSize / 2;

--- a/app/assets/javascripts/controllers/tanka_image_controller.js
+++ b/app/assets/javascripts/controllers/tanka_image_controller.js
@@ -287,11 +287,14 @@ export default class extends Controller {
     }
 
     const baseHeight = (baseCharacters.length - 1) * lineHeight + fontSize;
+    const baseCenterY = y + ((baseCharacters.length - 1) * lineHeight) / 2;
+    const naturalRubyLineHeight = rubyFontSize * 0.95;
     const rubyLineHeight =
       rubyCharacters.length > 1
-        ? Math.max((baseHeight - rubyFontSize) / (rubyCharacters.length - 1), rubyFontSize * 0.9)
-        : rubyFontSize * 0.9;
-    const rubyY = y - baseHeight / 2 + rubyFontSize / 2;
+        ? Math.min(naturalRubyLineHeight, (baseHeight - rubyFontSize) / (rubyCharacters.length - 1))
+        : naturalRubyLineHeight;
+    const rubyHeight = (rubyCharacters.length - 1) * rubyLineHeight + rubyFontSize;
+    const rubyY = baseCenterY - rubyHeight / 2 + rubyFontSize / 2;
 
     rubyCharacters.forEach((character, index) => {
       context.font = `${rubyFontSize}px serif`;

--- a/app/assets/javascripts/controllers/tanka_image_controller.js
+++ b/app/assets/javascripts/controllers/tanka_image_controller.js
@@ -274,7 +274,6 @@ export default class extends Controller {
   drawRuby(context, unit, x, y, fontSize, lineHeight) {
     const baseCharacters = Array.from(unit.text);
     const rubyCharacters = Array.from(unit.ruby);
-    const rubyFontSize = Math.max(Math.round(fontSize * 0.34), 14);
     const rubyX = x + fontSize * 0.62;
 
     baseCharacters.forEach((character, index) => {
@@ -288,11 +287,14 @@ export default class extends Controller {
 
     const baseHeight = (baseCharacters.length - 1) * lineHeight + fontSize;
     const baseCenterY = y + ((baseCharacters.length - 1) * lineHeight) / 2;
-    const naturalRubyLineHeight = rubyFontSize * 0.95;
-    const rubyLineHeight =
-      rubyCharacters.length > 1
-        ? Math.min(naturalRubyLineHeight, (baseHeight - rubyFontSize) / (rubyCharacters.length - 1))
-        : naturalRubyLineHeight;
+    const rubyLineHeightRatio = 0.95;
+    const fittedRubyFontSize =
+      baseHeight / (1 + Math.max(rubyCharacters.length - 1, 0) * rubyLineHeightRatio);
+    const rubyFontSize = Math.max(
+      Math.min(Math.round(fittedRubyFontSize), Math.round(fontSize * 0.62)),
+      14,
+    );
+    const rubyLineHeight = rubyFontSize * rubyLineHeightRatio;
     const rubyHeight = (rubyCharacters.length - 1) * rubyLineHeight + rubyFontSize;
     const rubyY = baseCenterY - rubyHeight / 2 + rubyFontSize / 2;
 

--- a/app/assets/javascripts/controllers/tanka_image_controller.js
+++ b/app/assets/javascripts/controllers/tanka_image_controller.js
@@ -286,12 +286,12 @@ export default class extends Controller {
       return;
     }
 
-    const baseHeight = (baseCharacters.length - 1) * lineHeight;
+    const baseHeight = (baseCharacters.length - 1) * lineHeight + fontSize;
     const rubyLineHeight =
-      baseCharacters.length > 1
-        ? baseHeight / Math.max(rubyCharacters.length - 1, 1)
+      rubyCharacters.length > 1
+        ? Math.max((baseHeight - rubyFontSize) / (rubyCharacters.length - 1), rubyFontSize * 0.9)
         : rubyFontSize * 0.9;
-    const rubyY = y + baseHeight / 2 - ((rubyCharacters.length - 1) * rubyLineHeight) / 2;
+    const rubyY = y - baseHeight / 2 + rubyFontSize / 2;
 
     rubyCharacters.forEach((character, index) => {
       context.font = `${rubyFontSize}px serif`;


### PR DESCRIPTION
## 概要
- 短歌画像のルビ配置で、親文字列の中心間隔だけでなく文字サイズを含めた高さを基準にしました
- ルビの字間を広げるのではなく、親文字列の高さとルビ文字数からルビ文字サイズを決めるようにしました
- ルビサイズの上限と親文字からの横方向の余白を調整し、縦幅を使いつつ親文字へ触れにくい表示にしました

## 確認
- npm run lint
- docker compose run --rm app bin/rubocop

Resolves #1084