### PR TITLE
docker compose build時に既存のimageが残らないようにする

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -1,7 +1,6 @@
 services:
   app:
     build: .
-    image: app:latest
     volumes:
       - .:/app:cached
       - bundle:/app/vendor/bundle


### PR DESCRIPTION
## 概要
- appサービスに明示していた `image: app:latest` を削除しました
- `docker compose build` 時に `app:latest` タグを毎回付け替えないようにしました

## 原因
`image: app:latest` を指定している状態で `docker compose build` を実行すると、新しくビルドされたイメージに同じ `app:latest` タグが付与されます。

Dockerのタグは同じ名前を複数のイメージに付けられないため、以前 `app:latest` だったイメージからタグが外れ、結果として `<none>` のdangling imageとして残っていました。

## 対応
開発用のappイメージに固定タグを明示しないようにして、Composeが生成するプロジェクト単位のイメージ名に任せるようにしました。これにより、`app:latest` の付け替えによって古いイメージが `<none>` として残る状況を避けます。

## 確認
- docker compose config

Resolves #1129