### PR TITLE
Hotwire Native向けにWeb UIを整理する

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -148,6 +148,10 @@ h5 {
   font-weight: 600;
 }
 
+body.hotwire-native .web-only {
+  display: none;
+}
+
 .horizontal {
   -webkit-writing-mode: horizontal-tb;
   -ms-writing-mode: rl;
@@ -258,6 +262,10 @@ label {
   overflow-x: scroll;
   overflow-y: hidden;
   min-height: calc(100vh - 67px);
+}
+
+body.hotwire-native .tanka-index {
+  min-height: 100vh;
 }
 
 .tanka-link {

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -1,4 +1,4 @@
-<header>
+<header class="web-only">
   <nav class="navbar navbar-expand-lg navbar-dark py-0">
     <%= link_to 'Utakata', posts_path, class: 'navbar-brand' %>
     <% if current_user %>

--- a/app/views/users/followees/index.html.erb
+++ b/app/views/users/followees/index.html.erb
@@ -7,7 +7,7 @@
       <button class="toggle-button">
         <%= link_to 'フォロワー', users_user_followers_path(@user), class: 'text-secondary' %>
       </button>
-      <button class="toggle-button">
+      <button class="toggle-button web-only">
         <%= link_to '戻る', user_path(@user), class: 'text-secondary' %>
       </button>
     </div>
@@ -20,7 +20,7 @@
       <button class="toggle-button">
         <%= link_to 'フォロワー', users_user_followers_path(@user), class: 'text-secondary' %>
       </button>
-      <button class="toggle-button">
+      <button class="toggle-button web-only">
         <%= link_to '戻る', user_path(@user), class: 'text-secondary' %>
       </button>
     </div>

--- a/app/views/users/followers/index.html.erb
+++ b/app/views/users/followers/index.html.erb
@@ -7,7 +7,7 @@
         <%= link_to 'フォロー', users_user_followees_path(@user), class: 'text-secondary' %>
       </button>
       <button class="toggle-button selected">フォロワー</button>
-      <button class="toggle-button">
+      <button class="toggle-button web-only">
         <%= link_to '戻る', user_path(@user), class: 'text-secondary' %>
       </button>
     </div>
@@ -20,7 +20,7 @@
         <%= link_to 'フォロー', users_user_followees_path(@user), class: 'text-secondary' %>
       </button>
       <button class="toggle-button selected">フォロワー</button>
-      <button class="toggle-button">
+      <button class="toggle-button web-only">
         <%= link_to '戻る', user_path(@user), class: 'text-secondary' %>
       </button>
     </div>

--- a/test/controllers/hotwire_native_test.rb
+++ b/test/controllers/hotwire_native_test.rb
@@ -14,6 +14,7 @@ class HotwireNativeTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     assert_select 'body.hotwire-native'
+    assert_select 'header.web-only'
   end
 
   test 'does not mark regular browser requests as native' do
@@ -21,5 +22,6 @@ class HotwireNativeTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     assert_select 'body.hotwire-native', count: 0
+    assert_select 'header.web-only'
   end
 end

--- a/test/controllers/hotwire_native_test.rb
+++ b/test/controllers/hotwire_native_test.rb
@@ -3,13 +3,13 @@
 require 'test_helper'
 
 class HotwireNativeTest < ActionDispatch::IntegrationTest
-  test 'has a valid path configuration for iOS' do
+  test 'iOS向けのパス設定が有効であること' do
     configuration = JSON.parse(Rails.public_path.join('configurations/ios_v1.json').read)
 
     assert_kind_of Array, configuration.fetch('rules')
   end
 
-  test 'marks requests from the Hotwire Native app' do
+  test 'Hotwire Nativeアプリからのリクエストではbody要素にクラスを付与すること' do
     get about_index_path, headers: { 'User-Agent' => 'Utakata Hotwire Native iOS; Turbo Native iOS;' }
 
     assert_response :success
@@ -17,7 +17,7 @@ class HotwireNativeTest < ActionDispatch::IntegrationTest
     assert_select 'header.web-only'
   end
 
-  test 'does not mark regular browser requests as native' do
+  test '通常ブラウザからのリクエストではbody要素にクラスを付与しないこと' do
     get about_index_path
 
     assert_response :success

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -5,8 +5,5 @@ require File.expand_path('../config/environment', __dir__)
 require 'rails/test_help'
 
 class ActiveSupport::TestCase
-  # test/fixtures/*.ymlにあるすべてのフィクスチャをアルファベット順に読み込む。
   fixtures :all
-
-  # すべてのテストで使用するヘルパーメソッドはここに追加する。
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -5,8 +5,8 @@ require File.expand_path('../config/environment', __dir__)
 require 'rails/test_help'
 
 class ActiveSupport::TestCase
-  # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.
+  # test/fixtures/*.ymlにあるすべてのフィクスチャをアルファベット順に読み込む。
   fixtures :all
 
-  # Add more helper methods to be used by all tests here...
+  # すべてのテストで使用するヘルパーメソッドはここに追加する。
 end


### PR DESCRIPTION
## 背景

iOSアプリではネイティブ側で主要なナビゲーションを提供するため、Web Navbarやネイティブの戻る操作と重複するUIをHotwire Native上では表示しないようにする。

通常のWebブラウザでは、従来どおりWeb向けのナビゲーションを利用できる状態を維持する。

## 変更内容

- Web向けUIを示す `web-only` クラスを追加し、`body.hotwire-native` 配下でのみ非表示にした
- トップ、タイムライン、検索、通知、マイページ、投稿、その他の導線を持つNavbar全体をWeb向けUIとして整理した
- フォロー・フォロワー一覧の「戻る」を、iOSの戻る操作と重複するWeb向けUIとして整理した
- フォロー・フォロワーの切り替えや投稿・編集など、各画面の内容に属する操作はWeb画面内に残した
- Navbarを非表示にしたHotwire Nativeでは、短歌一覧の高さからNavbar分を差し引かないよう調整した
- 通常ブラウザでもNavbarのマークアップが維持されることをテストした

## 動作確認

- `docker compose run --rm app bin/rails test`
  - 3 tests、10 assertions、0 failures、0 errors
- `docker compose run --rm app bin/rubocop`
  - 72 files inspected、no offenses detected
- `npm run lint`
  - 13 files checked、警告・エラーなし

Resolves #1166