### PR TITLE
GitHub ActionsにRailsのユニットテストを実行するCIを追加する

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -32,3 +32,45 @@ jobs:
         run: bundle install
       - name: Run RuboCop
         run: bin/rubocop --parallel
+
+  test:
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:17
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: password
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      RAILS_ENV: test
+      DATABASE_HOST: localhost
+      DATABASE_USER: postgres
+      DATABASE_PASSWORD: password
+
+    steps:
+      - uses: actions/checkout@v7
+      - name: Use Node.js 24
+        uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          cache: npm
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 4.0
+          bundler-cache: true
+      - name: Install JavaScript dependencies
+        run: npm ci
+      - name: Prepare database
+        run: bin/rails db:prepare
+      - name: Run Rails tests
+        run: bin/rails test


### PR DESCRIPTION
## 背景

Railsのユニットテストを継続的に実行するCIがなく、変更によるテストの失敗をPull Request上で検知できない状態でした。

## 変更内容

- GitHub ActionsのRubyワークフローにRailsテスト用ジョブを追加しました
- PostgreSQL 17のサービスコンテナを起動し、テスト用データベースを準備するようにしました
- Node.js 24とRuby 4.0の依存関係をセットアップし、`bin/rails test`を実行するようにしました

## 動作確認

- `docker compose run --rm app bin/rails test`
  - 3 runs、6 assertions、0 failures、0 errors、0 skips
- `docker compose run --rm app bin/rubocop`
  - 72 files inspected、no offenses detected
- RubyのYAMLパーサーによる`.github/workflows/ruby.yml`の構文確認
- `git diff --check`

Resolves #1171
