### PR TITLE
SwiftのGitHub CodeQLがエラーになる問題を解消する

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -12,6 +12,23 @@ permissions:
   contents: read
 
 jobs:
+  build-swift-without-codeql:
+    name: Build Swift without CodeQL
+    runs-on: macos-latest
+
+    steps:
+      - uses: actions/checkout@v7
+      - name: Build Swift application
+        working-directory: ios
+        run: |
+          /usr/bin/time -p xcodebuild build \
+            -project Utakata.xcodeproj \
+            -scheme Utakata \
+            -sdk iphoneos \
+            -derivedDataPath "$RUNNER_TEMP/UtakataDerivedData" \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGNING_ALLOWED=NO
+
   analyze:
     name: Analyze (${{ matrix.language }})
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -58,16 +58,31 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
+      - name: Prepare Swift dependencies without CodeQL
+        if: matrix.language == 'swift'
+        working-directory: ios
+        run: |
+          /usr/bin/time -p xcodebuild build \
+            -project Utakata.xcodeproj \
+            -scheme Utakata \
+            -sdk iphoneos \
+            -derivedDataPath "$RUNNER_TEMP/UtakataDerivedData" \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGNING_ALLOWED=NO
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
+      - name: Mark Utakata Swift sources for recompilation
+        if: matrix.language == 'swift'
+        working-directory: ios
+        run: find Utakata -type f -name '*.swift' -print -exec touch {} +
       - name: Build Swift application
         if: matrix.language == 'swift'
         working-directory: ios
         run: |
-          xcodebuild build \
+          /usr/bin/time -p xcodebuild build \
             -project Utakata.xcodeproj \
             -scheme Utakata \
             -sdk iphoneos \

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,61 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  schedule:
+    - cron: '0 20 * * 0'
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ${{ matrix.os }}
+
+    permissions:
+      actions: read
+      contents: read
+      packages: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: actions
+            build-mode: none
+            os: ubuntu-latest
+          - language: javascript-typescript
+            build-mode: none
+            os: ubuntu-latest
+          - language: ruby
+            build-mode: none
+            os: ubuntu-latest
+          - language: swift
+            build-mode: manual
+            os: macos-latest
+
+    steps:
+      - uses: actions/checkout@v7
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+      - name: Build Swift application
+        if: matrix.language == 'swift'
+        working-directory: ios
+        run: |
+          xcodebuild build \
+            -project Utakata.xcodeproj \
+            -scheme Utakata \
+            -sdk iphoneos \
+            -derivedDataPath "$RUNNER_TEMP/UtakataDerivedData" \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGNING_ALLOWED=NO
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v4


### PR DESCRIPTION
## 背景

CodeQLのSwift自動ビルドはXcodeプロジェクトのターゲットを直接ビルドしますが、Swift Packageのリソースバンドルとアプリでビルド先が分かれ、`HotwireNative_HotwireNative.bundle`のコピーに失敗していました。

Swiftでは手動ビルドを利用できるため、共有スキームを指定して同じDerived Data配下で依存関係をビルドします。

- [CodeQLのコンパイル言語向けビルド設定](https://docs.github.com/en/code-security/reference/code-scanning/codeql/build-options-for-compiled-languages)

## 変更内容

- CodeQLをAdvanced setupで実行するworkflowを追加しました
- Actions、JavaScript/TypeScript、RubyはUbuntu上でビルドなし解析を実行します
- SwiftはmacOS上で`Utakata`共有スキームを手動ビルドしてから解析します
- masterへのpush、pull request、週次スケジュールで解析を実行します

## 動作確認

以下のコマンドで、workflowと同じSwiftビルドが成功することを確認しました。

```sh
xcodebuild build \
  -project ios/Utakata.xcodeproj \
  -scheme Utakata \
  -sdk iphoneos \
  -derivedDataPath /tmp/utakata-codeql-derived-data \
  CODE_SIGNING_REQUIRED=NO \
  CODE_SIGNING_ALLOWED=NO
```

- YAML構文の読み込み
- `git diff --check`

Resolves #1188