### PR TITLE
XアカウントIDの正規化方法を見直す

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,7 +14,7 @@ class User < ApplicationRecord
          :validatable,
          :confirmable
 
-  before_validation :remove_twitter_id_at_mark
+  normalizes :twitter_id, with: ->(twitter_id) { twitter_id.delete_prefix('@') }
 
   has_many :posts, dependent: :destroy
   has_attached_file :avatar,
@@ -39,11 +39,5 @@ class User < ApplicationRecord
 
   def today_posts_count
     posts.where(created_at: Time.zone.now.midnight..).count
-  end
-
-  private
-
-  def remove_twitter_id_at_mark
-    self.twitter_id = twitter_id.delete_prefix('@') if twitter_id.present?
   end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -21,15 +21,6 @@ describe User do
       assert_equal 'utakatanka', user.reload.twitter_id
     end
 
-    it '保存済みの先頭に@がある値を不正と判定する' do
-      user = users(:hanako)
-      User.connection.execute(<<~SQL.squish)
-        UPDATE users SET twitter_id = '@utakatanka' WHERE id = #{user.id}
-      SQL
-
-      assert_not user.reload.valid?
-    end
-
     it '先頭に@が複数ある値を登録できない' do
       user = users(:hanako)
 

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -21,6 +21,15 @@ describe User do
       assert_equal 'utakatanka', user.reload.twitter_id
     end
 
+    it '保存済みの先頭に@がある値を不正と判定する' do
+      user = users(:hanako)
+      User.connection.execute(<<~SQL.squish)
+        UPDATE users SET twitter_id = '@utakatanka' WHERE id = #{user.id}
+      SQL
+
+      assert_not user.reload.valid?
+    end
+
     it '先頭に@が複数ある値を登録できない' do
       user = users(:hanako)
 


### PR DESCRIPTION
## 背景

XアカウントIDの先頭に付いた@をbefore_validationで除去していたため、DBに@付きの不正値が保存済みでも、valid?の実行時に値が書き換わって正常と判定されていた。

## 変更内容

- XアカウントIDの先頭の@を除去する処理をRails 8.1のnormalizesへ移行した
- ユーザー入力時は従来どおり@を除去しつつ、DBに保存済みの@付き値はバリデーションエラーになるようにした
- DBに不正値が残っている状態を再現する回帰テストを追加した

参考: https://api.rubyonrails.org/classes/ActiveRecord/Normalization/ClassMethods.html

## 動作確認

- docker compose run --rm app bin/test
  - 72 runs, 202 assertions, 0 failures, 0 errors, 0 skips
- docker compose run --rm app bin/rubocop
  - 99 files inspected, no offenses detected

Resolves #1204